### PR TITLE
#2: Fix Clean Kill Crash

### DIFF
--- a/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
+++ b/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
@@ -416,7 +416,7 @@ function ZyruIncremental.ProcessDamageEnemyValues (damageResult, args)
 
     -- CleanKill
     if HeroHasTrait("ArtemisCriticalTrait") then
-      local critDamage = GetUnitDataValue{ Id = 40000, WeaponName = GetEquippedWeapon(), Property = "CritMultiplierAddition" }
+      local critDamage = GetUnitDataValue{ Id = 40000, WeaponName = GetEquippedWeapon(), Property = "CritMultiplierAddition" } or 0
       critDamageMap["ArtemisCriticalTrait"] = critDamage
       critDamageTotal = critDamageTotal + critDamage
     end


### PR DESCRIPTION
Need to reinvestigate this later, as the engine value should not return nil. Just addressing the crash for now.