### PR TITLE
Deflect Experience, Thanatos EXP Mitigation, and others

### DIFF
--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
@@ -191,6 +191,7 @@ ModUtil.LoadOnce(function ( )
       ZeroRangedWeaponAmmoMultiplier = "ZeroAmmoBonusTrait",
       AthenaBackstabVulnerability = "AthenaBackstabDebuffTrait",
       DionysusComboVulnerability = "DionysusComboVulnerability",
+      ProjectileDeflectedMultiplier = "AthenaShieldTrait",
       ---------------
       -- DEFENSIVE --
       ---------------

--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
@@ -263,8 +263,8 @@ ModUtil.LoadOnce(function ( )
       AthenaShoutTrait = 0, -- NA
       EnemyDamageTrait = 1,
       TrapDamageTrait = 1,
-      LastStandHealTrait = 1,
-      LastStandDurationTrait = 1,
+      LastStandHealTrait = 0,
+      LastStandDurationTrait = 0,
       PreloadSuperGenerationTrait =  1,
       AthenaRetaliateTrait = 1,
       ShieldHitTrait = 0, -- NA
@@ -448,8 +448,8 @@ ModUtil.LoadOnce(function ( )
       AthenaShoutTrait = 100,
       EnemyDamageTrait = 0,
       TrapDamageTrait = 0,
-      LastStandHealTrait = 0,
-      LastStandDurationTrait = 0,
+      LastStandHealTrait = 500,
+      LastStandDurationTrait = 500,
       PreloadSuperGenerationTrait = 0,
       AthenaRetaliateTrait = 0,
       ShieldHitTrait = 250,

--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
@@ -101,6 +101,7 @@ ModUtil.LoadOnce(function ( )
       AphroditeMaxSuperCharm = "AphroditeShoutTrait",
       -- Artemis
       ArtemisShoutWeapon = "ArtemisShoutTrait",
+      ArtemisMaxShoutWeapon = "ArtemisShoutTrait",
       ArtemisAmmoWeapon = "ArtemisAmmoExitTrait",
       -- Demeter
       ChillRetaliate = "DemeterRetaliateTrait",

--- a/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
+++ b/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
@@ -249,6 +249,13 @@ local ignoreDamageSourceTraitMap = {
 ModUtil.Table.Merge(ignoreDamageSourceTraitMap, ToLookup(LootData.WeaponUpgrade.Traits))
 -- Well items
 ModUtil.Table.Merge(ignoreDamageSourceTraitMap, ToLookup(StoreData.RoomShop.Traits))
+-- keepsakes
+ModUtil.Table.Merge(
+  ignoreDamageSourceTraitMap,
+  ToLookup(
+    GameData.AchievementData.AchLeveledKeepsakes.CompleteGameStateRequirements.RequiresMaxKeepsakes
+  )
+)
 
 -- TODO: reinvestigate post crash-fixes
 --[[

--- a/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
+++ b/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
@@ -824,6 +824,12 @@ ModUtil.Path.Context.Wrap("Damage", function ()
     local armorBeforeAttack = victim.HealthBuffer or 0
     local res = baseFunc( victim, triggerArgs )
     triggerArgs = triggerArgs or {}
+    -- go away, than
+    if triggerArgs.triggeredById ~= CurrentRun.Hero.ObjectId then
+      return res
+    end
+
+
     local args = {
       Victim = victim,
       TriggerArgs = {
@@ -839,14 +845,6 @@ ModUtil.Path.Context.Wrap("Damage", function ()
         IsCrit = triggerArgs.IsCrit,
       }
     }
-    
-    ZyruIncremental.Debug = DeepCopyTable(triggerArgs)
-
-    if triggerArgs.ProjectileDeflected then
-      if HeroHasTrait("AthenaShieldTrait") then
-        boonsUsed["AthenaShieldTrait"] = damageResult.BaseDamage
-      end
-    end
 
     thread( ZyruIncremental.ProcessDamageEnemyValues, damageResult, args)
 

--- a/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
+++ b/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
@@ -442,14 +442,14 @@ function ZyruIncremental.ProcessDamageEnemyValues (damageResult, args)
     -- TODO: GetEffectTimeRemaining
     -- if HeroHasTrait("ArtemisReflectBuffTrait") and GetEffectTimeRemaining{ WeaponName = "ArtemisReflectBuff", EffectName = "ReflectCritChance", Property = "Duration" } then
     if HeroHasTrait("ArtemisReflectBuffTrait") and GetEffectDataValue{ WeaponName = "ArtemisReflectBuff", EffectName = "ReflectCritChance", Property = "Duration" } then
-      local critChance = GetEffectDataValue{ WeaponName = "ArtemisReflectBuff", EffectName = "ReflectCritChance", Property = "CritAddition" }
+      local critChance = GetEffectDataValue{ WeaponName = "ArtemisReflectBuff", EffectName = "ReflectCritChance", Property = "CritAddition" } or 0
       critChanceMap["ArtemisReflectBuffTrait"] = critChance
       critChanceTotal = critChanceTotal + critChance
     end
 
     -- CleanKill
     if HeroHasTrait("ArtemisCriticalTrait") then
-      local critDamage = GetUnitDataValue{ Id = 40000, WeaponName = GetEquippedWeapon(), Property = "CritMultiplierAddition" }
+      local critDamage = GetUnitDataValue{ Id = 40000, WeaponName = GetEquippedWeapon(), Property = "CritMultiplierAddition" } or 0
       critDamageMap["ArtemisCriticalTrait"] = critDamage
       critDamageTotal = critDamageTotal + critDamage
     end
@@ -824,8 +824,11 @@ ModUtil.Path.Context.Wrap("Damage", function ()
     local armorBeforeAttack = victim.HealthBuffer or 0
     local res = baseFunc( victim, triggerArgs )
     triggerArgs = triggerArgs or {}
+
     -- go away, than
-    if triggerArgs.triggeredById ~= CurrentRun.Hero.ObjectId then
+    local attackerIsHero = triggerArgs.AttackerId == CurrentRun.Hero.ObjectId
+    local selfDeflectDamage =  triggerArgs.ProjectileDeflected
+    if not attackerIsHero and not selfDeflectDamage then
       return res
     end
 

--- a/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
+++ b/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
@@ -439,6 +439,8 @@ function ZyruIncremental.ProcessDamageEnemyValues (damageResult, args)
       critChanceTotal = critChanceTotal + critChance
     end
     -- Has Deadly Reversal AND its active
+    -- TODO: GetEffectTimeRemaining
+    -- if HeroHasTrait("ArtemisReflectBuffTrait") and GetEffectTimeRemaining{ WeaponName = "ArtemisReflectBuff", EffectName = "ReflectCritChance", Property = "Duration" } then
     if HeroHasTrait("ArtemisReflectBuffTrait") and GetEffectDataValue{ WeaponName = "ArtemisReflectBuff", EffectName = "ReflectCritChance", Property = "Duration" } then
       local critChance = GetEffectDataValue{ WeaponName = "ArtemisReflectBuff", EffectName = "ReflectCritChance", Property = "CritAddition" }
       critChanceMap["ArtemisReflectBuffTrait"] = critChance

--- a/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
+++ b/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
@@ -1188,6 +1188,7 @@ function ModInitializationScreen2()
                                 OffsetY = 0,
                                 OffsetX = 0,
                                 Justification = "Center",
+                                VerticalJustification = "Center"
                             }
                         },
                         ComponentArgs = {

--- a/Mods/ZyruviasIncremental/Upgrades/ZyruIncrementalUpgrades.lua
+++ b/Mods/ZyruviasIncremental/Upgrades/ZyruIncrementalUpgrades.lua
@@ -1,15 +1,19 @@
-function ZyruIncremental.AddUpgrade(upgradeName, args)
-    args = args or {}
+function ZyruIncremental.AddUpgrade(upgrade, args)
     if ZyruIncremental.Data == nil or ZyruIncremental.Data.UpgradeData == nil then
         -- DebugPrint { Text = "GameState not properly defined"}
         return false
     end
+    if upgrade == nil then
+        DebugPrint { Text = "Passed nil upgrade"}
+        return false
+    end
+    local upgradeName = upgrade.Name
+    args = args or {}
     table.insert(ZyruIncremental.Data.UpgradeData, upgradeName)
     if args.SkipApply then
         return true
     end
 
-    local upgrade = ZyruIncremental.UpgradeData[upgradeName]
     if upgrade.OnApplyFunction ~= nil then
         _G[upgrade.OnApplyFunction](upgrade.OnApplyFunctionArgs)
     end
@@ -79,8 +83,8 @@ function ZyruIncremental.MergeDataArrays(args)
     end
 end
 
-function ZyruIncremental.HasUpgrade(upgradeName, args)
-    return Contains(ZyruIncremental.Data.UpgradeData, upgradeName)
+function ZyruIncremental.HasUpgrade(upgrade, args)
+    return Contains(ZyruIncremental.Data.UpgradeData, upgrade.Name)
 end
 
 function ZyruIncremental.GetAllUpgradesBySource(source)
@@ -142,7 +146,7 @@ end
 function ZyruIncremental.AttemptPurchaseUpgrade(screen, button)
     local upgrade = button.Upgrade
     DebugPrint { Text = ModUtil.ToString.Shallow(upgrade) }
-    if ZyruIncremental.HasUpgrade(upgrade.Name) and not ZyruIncremental.IsUpgradeRepeatable(upgrade) then
+    if ZyruIncremental.HasUpgrade(upgrade) and not ZyruIncremental.IsUpgradeRepeatable(upgrade) then
         -- TODO: CannotPurchaseVoiceLines all but last?
         DebugPrint { Text = "Already have upgrade: " .. upgrade.Name }
 		thread( PlayVoiceLines, HeroVoiceLines.CannotPurchaseVoiceLines, true )
@@ -152,7 +156,7 @@ function ZyruIncremental.AttemptPurchaseUpgrade(screen, button)
         -- subtract Cost
         SubtractUpgradeCosts(upgrade)
         -- add upgrade to save
-        ZyruIncremental.AddUpgrade(upgrade.Name)
+        ZyruIncremental.AddUpgrade(upgrade)
         -- exhibit signs of self awareness
 		thread( PlayVoiceLines, HeroVoiceLines.GenericUpgradePickedVoiceLines, true )
         DebugPrint { Text = "Purchased upgrade: " .. upgrade.Name }


### PR DESCRIPTION
* Deflect damage reflects back to the boon you used to deflect (kind of, it's a shared experience system since I can't determine which boon is doing the deflecting)
* Non-zag killers of things do not get you EXP.
* Keepsakes do not level up anymore.
* Athena DDs now grant experience on use (and all DD uses, since they still give benefits after the fact)
* Artemis Max call is now appropriately tracked.
* Fix Clean Kill for real this time? I think the commit got lost somehow.
* Fixes a bug where purchasing upgrades in the UI causes a crash