### PR TITLE
Enhance Courtyard tutorial direction hints

### DIFF
--- a/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
+++ b/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
@@ -697,6 +697,9 @@ end
 
 function ShowZyruSettingsMenu()
     ZyruIncremental.Data.Flags.SeenSettingsMenu = true
+    if ZyruIncremental.SettingsMenuObjectId ~= nil then
+        ActivatedObjects[ZyruIncremental.SettingsMenuObjectId] = nil
+    end
     local screen = ZyruIncremental.CreateMenu("SettingsMenu", {
         PauseBlock = true,
         Components = {


### PR DESCRIPTION
* All remaining necessary-to-see entities fire off direction hints instead of just one random hint.
* Mod Settings menu was not clearing the Activation flag on interact. This could be worked around by going into the bedroom and back, but still annoying.