### PR TITLE
Add Screen History functionality -- enables "Back" button behavior instead of closing for many screens

### DIFF
--- a/Mods/ZyruviasIncremental/UI/Framework.lua
+++ b/Mods/ZyruviasIncremental/UI/Framework.lua
@@ -791,28 +791,6 @@ function ZyruIncremental.RenderButton(screen, component)
     if buttonDefinition.Angle ~= nil then
         SetAngle({ Id = components[buttonName].Id, Angle = buttonDefinition.Angle})
     end
-    
-    -- components[buttonName].OnMouseOverFunctionName = "LolLmao"
-    -- components[buttonName].OnMouseOffFunctionName = "LolLmao"
-    -- HardCoded, not sure how to get around this
-    if buttonDefinition.OnPressedFunctionName == nil and component.SubType == "Close" then
-        local name = screen.Name
-        components[buttonName].OnPressedFunctionName = "Close" .. name .. "Screen"
-        if _G["Close" .. name .. "Screen"] == nil then
-    
-            _G["Close" .. name .. "Screen"] = function()
-                CloseScreenByName ( name )
-                if buttonDefinition.CloseScreenFunction then
-                    buttonDefinition.CloseScreenFunction(buttonDefinition.CloseScreenFunctionArgs)
-                elseif buttonDefinition.CloseScreenFunctionName ~= nil then
-                    _G[buttonDefinition.CloseScreenFunctionName](buttonDefinition.CloseScreenFunctionArgs)
-                end
-                _G["Close" .. name .. "Screen"] = nil
-            end
-        end
-    elseif buttonDefinition.OnPressedFunctionName == nil and component.SubType == "Back" then
-        components[buttonName].OnPressedFunctionName = "ScreenPageBack"
-    end
 
     -- LABELLED BUTTONS
     if buttonDefinition.Label then

--- a/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
+++ b/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
@@ -1666,11 +1666,7 @@ function ShowGodProgressScreen(screen, button)
         {
             -- TODO: fix this shit
             Type = "Button",
-            SubType = "Close",
-            ComponentArgs = {
-                PageIndex = 1,
-                OnPressedFunctionName = "GoToPageFromSource",
-            }
+            SubType = "Back",
         },
     }
     ZyruIncremental.RenderComponents(screen, componentsToRender)
@@ -1812,7 +1808,7 @@ function ShowZyruProgressScreen()
         },
         {
             Type = "Button",
-            SubType = "Close",
+            SubType = "Back",
         },
     }
     for i, name in ipairs({ "Zeus", "Poseidon", "Athena", "Ares", "Aphrodite", "Artemis", "Dionysus", "Hermes", "Demeter", "Chaos" }) do
@@ -1871,7 +1867,7 @@ function ShowZyruUpgradeScreen()
         },
         {
             Type = "Button",
-            SubType = "Close",
+            SubType = "Back",
         },
     }
     for i, name in ipairs({ "Zeus", "Poseidon", "Athena", "Ares", "Aphrodite", "Artemis", "Dionysus", "Hermes", "Demeter" }) do
@@ -2088,9 +2084,8 @@ function ShowGodUpgradeScreen(screen, button)
             }
         },
         {
-            -- TODO: Generalize for a "back" button instead of just close
             Type = "Button",
-            SubType = "Close",
+            SubType = "Back",
         },
     }
     ZyruIncremental.RenderComponents(screen, componentsToRender)


### PR DESCRIPTION
* Add Screen History stack object and relevant writes to the stack when changing pages
* Rework closing screen behavior to be a simple named reference and not a whole global env indexing piece of shit god awful nasty code
* Remove hardcoded button behavior, praise the fucking LORD