### PR TITLE
V1.1.0 into main

### DIFF
--- a/Mods/ZyruviasIncremental/Localization/helptext.en.sjson
+++ b/Mods/ZyruviasIncremental/Localization/helptext.en.sjson
@@ -272,5 +272,13 @@
             Id = "Boon_Olympic"
             DisplayName = "Olympic"
         }
+        {
+            Id = "Objective_ZyruResetGift"
+            DisplayName = "Give Hades an offering of {!Icons.GiftPoint} to take us all back ..."
+        }
+        {
+            Id = "ZyruResetGiftUseText"
+            DisplayName = "{G} Gift {#UseGiftPointFormat}( -{$TempTextData.GiftResourceAmount} {!Icons.GiftPoint}) (Lethe-infused)"
+        }
     ]
 }

--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalBoonData.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalBoonData.lua
@@ -244,7 +244,7 @@ ModUtil.LoadOnce(function ( )
       PoseidonShoutTrait = { RarityLevels = scalingTable(1.4, 0.1, 0.2) },
       DefensiveSuperGenerationTrait = { RarityLevels = scalingTable(2, 0.25) },
       EncounterStartOffenseBuffTrait = { RarityLevels = scalingTable(2, 0.25) },
-      RandomMinorLootDrop = { RarityLevels = scalingTable(2, 0.25) },
+      -- RandomMinorLootDrop = { RarityLevels = scalingTable(2, 0.25) },
 
       -- Hermes Boons
     -- RapidCastTrait = ZyruIncremental.Constants.Gods.HERMES,
@@ -299,6 +299,7 @@ ModUtil.LoadOnce(function ( )
     ModUtil.Table.Merge(TraitData.HarvestBoonTrait, {
 		  RoomsPerUpgrade = 5,
     })
+    SetupRunData()
   end, ZyruIncremental)
 
 -- SleepSoul's RCLib mappings as a baseline. Go check out his mods, he's brilliant.

--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
@@ -861,6 +861,7 @@ ModUtil.Path.Wrap("StartNewRun", function (baseFunc, ...)
   if not ZyruIncremental.Data.Flags or not ZyruIncremental.Data.Flags.Initialized then
     return run
   end 
+  ComputeSourceExpMultCache()
   ZyruIncremental.DifficultyModifier = ZyruIncremental.ComputeDifficultyModifier(
     ZyruIncremental.Data.FileOptions.DifficultySetting,
     ZyruIncremental.Constants.Difficulty.Keys.INCOMING_DAMAGE_SCALING

--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
@@ -821,12 +821,13 @@ end, ZyruIncremental)
 
 -- enemy data: newEnemy.HealthMultiplier
 ModUtil.Path.Wrap("SetupEnemyObject", function (baseFunc, newEnemy, currentRun, args)
-  local difficultyModifier = ZyruIncremental.DifficultyModifier or 1
+  local difficultyModifier = ZyruIncremental.Data.DifficultyModifier or 1
   newEnemy.HealthMultiplier = (newEnemy.HealthMultiplier or 1) * difficultyModifier
   -- armor
-  if newEnemy.HealthBuffer ~= nil and newEnemy.HealthBuffer > 0 then
-		newEnemy.HealthBufferMultiplier = (newEnemy.HealthBufferMultiplier or 1) * difficultyModifier
-	end
+  -- TODO: this is multiplying both armor and health, add intentionally as a difficulty setting
+  -- if newEnemy.HealthBuffer ~= nil and newEnemy.HealthBuffer > 0 then
+	-- 	newEnemy.HealthBufferMultiplier = (newEnemy.HealthBufferMultiplier or 1) * difficultyModifier
+	-- end
 
   return baseFunc(newEnemy, currentRun, args)
 end, ZyruIncremental)
@@ -886,13 +887,13 @@ ModUtil.Path.Wrap("StartNewRun", function (baseFunc, ...)
     return run
   end 
   ComputeSourceExpMultCache()
-  ZyruIncremental.DifficultyModifier = ZyruIncremental.ComputeDifficultyModifier(
+  ZyruIncremental.Data.DifficultyModifier = ZyruIncremental.ComputeDifficultyModifier(
     ZyruIncremental.Data.FileOptions.DifficultySetting,
     ZyruIncremental.Constants.Difficulty.Keys.INCOMING_DAMAGE_SCALING
   )
   AddIncomingDamageModifier(CurrentRun.Hero, {
     Name = "ZyruIncremental",
-    GlobalMultiplier = ZyruIncremental.DifficultyModifier
+    GlobalMultiplier = ZyruIncremental.Data.DifficultyModifier
   })
 
   return run

--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
@@ -838,23 +838,24 @@ function ZyruIncremental.ComputeNumRunsForCurrentPrestige()
   if ZyruIncremental.Data.FileOptions.StartingPoint == ZyruIncremental.Constants.SaveFile.FRESH_FILE then
     if GetNumRunsCleared() < 10 then
       return 1
-    elseif ZyruIncremental.Data.FreshFileRunCompletion == nil then
+    end
+    if ZyruIncremental.Data.FreshFileRunCompletion ~= nil then
+      return numRunsToExponentiate - ZyruIncremental.Data.FreshFileRunCompletion + 1
+    end
       -- compute the file-cached multiplier
       local runIndex = 0
-      local attemptIndex = 1
       for k, run in pairs( GameState.RunHistory ) do
         if run.Cleared then
           runIndex = runIndex + 1
         end
         if runIndex == 10 then
-          ZyruIncremental.Data.FreshFileRunCompletion = attemptIndex
+          ZyruIncremental.Data.FreshFileRunCompletion = k - 1
           break
         end
+
       end
-    end
     -- return the cached value
     -- e.g. 10th win on attempt 18, this is attempt 19, total length - 
-    numRunsToExponentiate = numRunsToExponentiate - ZyruIncremental.Data.FreshFileRunCompletion + 1
   end
 
   return numRunsToExponentiate

--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
@@ -59,10 +59,6 @@ function ZyruIncremental.InitializeSaveDataAndPatchIfNecessary  ()
   if  latestVer < 6 then
     ZyruIncremental.Data.PrestigeData = {}
     ZyruIncremental.Data.CurrentPrestige = 0
-    -- address bug where this value was cached incorrectly
-    if ZyruIncremental.Data.FileOptions.StartingPoint == ZyruIncremental.Constants.SaveFile.FRESH_FILE then
-      ZyruIncremental.Data.FreshFileRunCompletion = nil
-    end
   end
   -- UPDATE SAVE FILE TO BE LATEST VERSION
   ZyruIncremental.Data.Flags.MostRecentVersionPlayed = ZyruIncremental.CurrentVersion
@@ -843,21 +839,17 @@ function ZyruIncremental.ComputeNumRunsForCurrentPrestige()
     if GetNumRunsCleared() < 10 then
       return 1
     end
-    if ZyruIncremental.Data.FreshFileRunCompletion ~= nil then
-      return numRunsToExponentiate - ZyruIncremental.Data.FreshFileRunCompletion + 1
-    end
-      -- compute the file-cached multiplier
-      local runIndex = 0
-      for k, run in pairs( GameState.RunHistory ) do
-        if run.Cleared then
-          runIndex = runIndex + 1
-        end
-        if runIndex == 10 then
-          ZyruIncremental.Data.FreshFileRunCompletion = k - 1
-          break
-        end
-
+    -- compute the file-cached multiplier
+    local runIndex = 0
+    for k, run in pairs( GameState.RunHistory ) do
+      if run.Cleared then
+        runIndex = runIndex + 1
       end
+      if runIndex == 10 then
+        return numRunsToExponentiate - k
+      end
+
+    end
     -- return the cached value
     -- e.g. 10th win on attempt 18, this is attempt 19, total length - 
   end

--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
@@ -1,44 +1,36 @@
 -- SAVE DATA SETUP
-ZyruIncremental.InitializeSaveDataAndPatchIfNecessary = function ()
+function ZyruIncremental.InitializeGodData()
+  ZyruIncremental.Data.GodData = { 
+    Zeus = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
+    Poseidon = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
+    Athena = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
+    Aphrodite = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
+    Artemis = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
+    Ares = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
+    Dionysus = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
+    Hermes = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
+    Demeter = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
+    Chaos = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
+  }
+end
+
+function ZyruIncremental.InitializeDropData()
+  ZyruIncremental.Data.DropData = {
+    RoomRewardMoneyDrop = { Level = 1, Count = 0, Amount = 0, Experience = 0 },
+    RoomRewardMaxHealthDrop = { Level = 1, Count = 0, Amount = 0, Experience = 0 },
+    StackUpgrade = { Level = 1, Count = 0, Amount = 0, Experience = 0 },
+  }
+end
+
+function ZyruIncremental.InitializeSaveDataAndPatchIfNecessary  ()
   if not ZyruIncremental.Data.Flags or ZyruIncremental.Data.Flags.Initialized == nil then
     ZyruIncremental.Data.BoonData = { } -- Set Dynamically
       -- levevl, rarity bonus, experience, max points, current points
-    ZyruIncremental.Data.GodData = { 
-      Zeus = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
-      Poseidon = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
-      Athena = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
-      Aphrodite = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
-      Artemis = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
-      Ares = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
-      Dionysus = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
-      Hermes = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
-      Demeter = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
-      Chaos = { Level = 1, RarityBonus = 0, Experience = 0, CurrentPoints = 0, MaxPoints = 0, },
-    }
+      ZyruIncremental.InitializeGodData()
     -- track acquisition of runources: health / gold
-    -- meta currencies???
-    ZyruIncremental.Data.DropData = {
-      RoomRewardMoneyDrop = { Level = 1, Count = 0, Amount = 0, Experience = 0 },
-      RoomRewardMaxHealthDrop = { Level = 1, Count = 0, Amount = 0, Experience = 0 },
-      StackUpgrade = { Level = 1, Count = 0, Amount = 0, Experience = 0 },
-    }
+    ZyruIncremental.InitializeDropData()
     -- Dynamically set / prescribed
-    --[[
-      Upgrade shape: {
-        Name
-        CostType
-        Cost
-        OnApplyFunction
-        OnApplyFunctionArgs
-        Purchased
-      }
-    ]]--
-    ZyruIncremental.Data.UpgradeData = {
-      
-    }
-    ZyruIncremental.Data.Currencies = {
-      
-    }
+    ZyruIncremental.Data.UpgradeData = {}
     ZyruIncremental.Data.FileOptions = {
       StartingPoint = ZyruIncremental.Constants.SaveFile.EPILOGUE,
       DifficultySetting = ZyruIncremental.Constants.SaveFile.STANDARD,
@@ -48,11 +40,27 @@ ZyruIncremental.InitializeSaveDataAndPatchIfNecessary = function ()
     ZyruIncremental.Data.Flags = {
       Initialized = true,
     }
+    --[[
+      {
+        ExperienceMulitpliers {source: number}
+        BoonData
+        GodData
+        DropData
+        Upgrades
+
+      }
+    ]]
+    ZyruIncremental.Data.PrestigeData = {}
+    ZyruIncremental.Data.CurrentPrestige = 0
   end
 
   -- APPLY VERSION PATCHES
   if not ZyruIncremental.Data.Flags.MostRecentVersionPlayed then
     ZyruIncremental.Data.Flags.MostRecentVersionPlayed = ZyruIncremental.CurrentVersion
+  end
+  if not ZyruIncremental.Data.PrestigeData then
+    ZyruIncremental.Data.PrestigeData = {}
+    ZyruIncremental.Data.CurrentPrestige = 0
   end
 end
 
@@ -65,18 +73,9 @@ ModUtil.LoadOnce( function ( )
 
   -- process existing upgrades
   for i, upgradeName in ipairs(ZyruIncremental.Data.UpgradeData) do
-    local upgrade = ZyruIncremental.UpgradeData[upgradeName]
+    local upgrade = ZyruIncremental.GetUpgradeByName(upgradeName)
     if upgrade == nil then
-      -- check upgrades themselves for a name match, reworked names recently
-      for u, uData in pairs(ZyruIncremental.UpgradeData) do
-        if uData.Name == upgradeName then
-          upgrade = uData
-        end
-      end
-      -- still not found? remove it 
-      if upgrade == nil then
-        return ZyruIncremental.RemoveUpgrade(upgradeName)
-      end
+      return ZyruIncremental.RemoveUpgrade(upgradeName)
 
     end
     if upgrade.OnApplyFunction ~= nil then

--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
@@ -840,7 +840,6 @@ function ZyruIncremental.ComputeNumRunsForCurrentPrestige()
     if GetNumRunsCleared() < 10 then
       return 1
     end
-    -- compute the file-cached multiplier
     local runIndex = 0
     for k, run in pairs( GameState.RunHistory ) do
       if run.Cleared then
@@ -849,10 +848,7 @@ function ZyruIncremental.ComputeNumRunsForCurrentPrestige()
       if runIndex == 10 then
         return numRunsToExponentiate - k
       end
-
     end
-    -- return the cached value
-    -- e.g. 10th win on attempt 18, this is attempt 19, total length - 
   end
 
   return numRunsToExponentiate

--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
@@ -42,7 +42,7 @@ function ZyruIncremental.InitializeSaveDataAndPatchIfNecessary  ()
     }
     --[[
       {
-        ExperienceMulitpliers {source: number}
+        ExperienceMultipliers {source: number}
         BoonData
         GodData
         DropData

--- a/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
+++ b/Mods/ZyruviasIncremental/Mappings/ZyruIncrementalMaps.lua
@@ -55,13 +55,17 @@ function ZyruIncremental.InitializeSaveDataAndPatchIfNecessary  ()
   end
 
   -- APPLY VERSION PATCHES
-  if not ZyruIncremental.Data.Flags.MostRecentVersionPlayed then
-    ZyruIncremental.Data.Flags.MostRecentVersionPlayed = ZyruIncremental.CurrentVersion
-  end
-  if not ZyruIncremental.Data.PrestigeData then
+  local latestVer = ZyruIncremental.Data.Flags.MostRecentVersionPlayed or 1
+  if  latestVer < 6 then
     ZyruIncremental.Data.PrestigeData = {}
     ZyruIncremental.Data.CurrentPrestige = 0
+    -- address bug where this value was cached incorrectly
+    if ZyruIncremental.Data.FileOptions.StartingPoint == ZyruIncremental.Constants.SaveFile.FRESH_FILE then
+      ZyruIncremental.Data.FreshFileRunCompletion = nil
+    end
   end
+  -- UPDATE SAVE FILE TO BE LATEST VERSION
+  ZyruIncremental.Data.Flags.MostRecentVersionPlayed = ZyruIncremental.CurrentVersion
 end
 
 ModUtil.LoadOnce(ZyruIncremental.InitializeSaveDataAndPatchIfNecessary)

--- a/Mods/ZyruviasIncremental/Tracking/Experience.lua
+++ b/Mods/ZyruviasIncremental/Tracking/Experience.lua
@@ -68,8 +68,8 @@ function ComputeCurrentSourceExpMult(source)
     end
     local multiplier = 1
     for i, prestigeData in ipairs(ZyruIncremental.Data.PrestigeData) do
-        if prestigeData.ExperienceMulitpliers ~= nil then
-            multiplier = multiplier * (prestigeData.ExperienceMulitpliers[source] or 1)
+        if prestigeData.ExperienceMultipliers ~= nil then
+            multiplier = multiplier * (prestigeData.ExperienceMultipliers[source] or 1)
         end
     end
     ZyruIncremental.CachedExpMultipliersByGod[source] = multiplier

--- a/Mods/ZyruviasIncremental/Tracking/Experience.lua
+++ b/Mods/ZyruviasIncremental/Tracking/Experience.lua
@@ -45,8 +45,10 @@ end
 
 function ComputeSourceExpMultCache()
     ZyruIncremental.CachedExpMultipliersByGod = {}
+    ZyruIncremental.CachedEnemyScalingMultiplier = 1
     for i, olympian in ipairs({ "Zeus", "Poseidon", "Athena", "Ares", "Aphrodite", "Artemis", "Dionysus", "Hermes", "Demeter", "Chaos" }) do
-        ComputeCurrentSourceExpMult(olympian)
+        local mult = ComputeCurrentSourceExpMult(olympian)
+        ZyruIncremental.CachedEnemyScalingMultiplier = ZyruIncremental.CachedEnemyScalingMultiplier * mult
     end
 end
 

--- a/Mods/ZyruviasIncremental/Tracking/Experience.lua
+++ b/Mods/ZyruviasIncremental/Tracking/Experience.lua
@@ -41,16 +41,30 @@ function ZyruIncremental.ComputeShrinePactExperienceMultiplier(args)
     return mixedValue
 end
 
--- TODO: cache these results
+
+
+function ComputeSourceExpMultCache()
+    ZyruIncremental.CachedExpMultipliersByGod = {}
+    for i, olympian in ipairs({ "Zeus", "Poseidon", "Athena", "Ares", "Aphrodite", "Artemis", "Dionysus", "Hermes", "Demeter", "Chaos" }) do
+        ComputeCurrentSourceExpMult(olympian)
+    end
+end
+
+ModUtil.LoadOnce(ComputeSourceExpMultCache)
+
 function ComputeCurrentSourceExpMult(source)
     local currentPrestige = ZyruIncremental.Data.CurrentPrestige
     if currentPrestige == 0 then
         return 1
     end
+    if ZyruIncremental.CachedExpMultipliersByGod[source] ~= nil then
+        return ZyruIncremental.CachedExpMultipliersByGod[source]
+    end
     local multiplier = 1
-    for i, prestigeData in ZyruIncremental.Data.PrestigeData do
+    for i, prestigeData in ipairs(ZyruIncremental.Data.PrestigeData) do
         multiplier = multiplier * (prestigeData.ExperienceMulitpliers[source] or 1)
     end
+    ZyruIncremental.CachedExpMultipliersByGod[source] = multiplier
     return multiplier
 end
 --[[
@@ -63,12 +77,8 @@ end
         - 100 points by god: 1.93x mult
 ]]
 function ComputeNextSourceExpMult(source)
-    local prevMult = ComputeCurrentSourceExpMult(source)
     -- GodData hardcoded
     local maxPointsObtained = ZyruIncremental.Data.GodData[source].MaxPoints
     local mult = math.pow((50 + maxPointsObtained) / 50, 0.6)
-
-    -- DebugPrint { Text = "Computing Next Source Mult: " .. source .. ": " .. tostring(mult) ", total mult: " .. tostring(prevMult * mult)  }
-
     return mult
 end

--- a/Mods/ZyruviasIncremental/Tracking/Experience.lua
+++ b/Mods/ZyruviasIncremental/Tracking/Experience.lua
@@ -1,22 +1,20 @@
 local shrineExpFactorTable = {
-	EnemyDamageShrineUpgrade = 1.05,
-	HealingReductionShrineUpgrade = 1.05,
-	ShopPricesShrineUpgrade = 1.1,
-	EnemyCountShrineUpgrade = 1.02,
-	BossDifficultyShrineUpgrade = 1.1,
-
-	EnemyHealthShrineUpgrade = 1.05,
-	EnemyEliteShrineUpgrade = 1.15,
-	MinibossCountShrineUpgrade = 1.1,
-	ForceSellShrineUpgrade = 1.2,
-	EnemySpeedShrineUpgrade = 1.1,
-
-	TrapDamageShrineUpgrade = 1.05,
-	MetaUpgradeStrikeThroughShrineUpgrade = 1.2,
-	EnemyShieldShrineUpgrade = 1.02,
-	ReducedLootChoicesShrineUpgrade = 1.25,
-	BiomeSpeedShrineUpgrade = 1.05,
-	NoInvulnerabilityShrineUpgrade = 1,
+    EnemyDamageShrineUpgrade = 1.05,
+    HealingReductionShrineUpgrade = 1.05,
+    ShopPricesShrineUpgrade = 1.1,
+    EnemyCountShrineUpgrade = 1.02,
+    BossDifficultyShrineUpgrade = 1.1,
+    EnemyHealthShrineUpgrade = 1.05,
+    EnemyEliteShrineUpgrade = 1.15,
+    MinibossCountShrineUpgrade = 1.1,
+    ForceSellShrineUpgrade = 1.2,
+    EnemySpeedShrineUpgrade = 1.1,
+    TrapDamageShrineUpgrade = 1.05,
+    MetaUpgradeStrikeThroughShrineUpgrade = 1.2,
+    EnemyShieldShrineUpgrade = 1.02,
+    ReducedLootChoicesShrineUpgrade = 1.25,
+    BiomeSpeedShrineUpgrade = 1.05,
+    NoInvulnerabilityShrineUpgrade = 1
 }
 
 function ZyruIncremental.ComputeShrinePactExperienceMultiplier(args)
@@ -29,19 +27,48 @@ function ZyruIncremental.ComputeShrinePactExperienceMultiplier(args)
     local additiveValue = 1
     local mixedValue = 1
     for i, pactConditionName in ipairs(ShrineUpgradeOrder) do
-		local upgradeData = MetaUpgradeData[pactConditionName]
+        local upgradeData = MetaUpgradeData[pactConditionName]
         local expFactor = shrineExpFactorTable[pactConditionName]
-        local pactConditionCount = GetNumMetaUpgrades( pactConditionName ) or 0
+        local pactConditionCount = GetNumMetaUpgrades(pactConditionName) or 0
         if pactConditionCount > 0 then
-        
             value = value * math.pow(expFactor, pactConditionCount)
             additiveValue = additiveValue + (expFactor - 1) * pactConditionCount
             mixedValue = mixedValue * ((expFactor - 1) * pactConditionCount + 1)
         end
-
-        
     end
     -- DebugPrint { Text = "Mult: " .. tostring(value) ..  ", Mixed: " .. tostring(mixedValue) .. ", Additive: " .. tostring(additiveValue)}
     ZyruIncremental.ShrinePactExperienceMultiplierCache = value
     return mixedValue
+end
+
+-- TODO: cache these results
+function ComputeCurrentSourceExpMult(source)
+    local currentPrestige = ZyruIncremental.Data.CurrentPrestige
+    if currentPrestige == 0 then
+        return 1
+    end
+    local multiplier = 1
+    for i, prestigeData in ZyruIncremental.Data.PrestigeData do
+        multiplier = multiplier * (prestigeData.ExperienceMulitpliers[source] or 1)
+    end
+    return multiplier
+end
+--[[
+    Computes next prestige's experience multipliers by given source.
+    FORMULA:
+    - New Multiplier = Math.pow([(50 + MaxPoints) / 50], 0.6) -- can vary exponent
+        - 10  points by god: 1.12x mult
+        - 25  points by god: 1.27x mult
+        - 50  points by god: 1.51x mult
+        - 100 points by god: 1.93x mult
+]]
+function ComputeNextSourceExpMult(source)
+    local prevMult = ComputeCurrentSourceExpMult(source)
+    -- GodData hardcoded
+    local maxPointsObtained = ZyruIncremental.Data.GodData[source].MaxPoints
+    local mult = math.pow((50 + maxPointsObtained) / 50, 0.6)
+
+    -- DebugPrint { Text = "Computing Next Source Mult: " .. source .. ": " .. tostring(mult) ", total mult: " .. tostring(prevMult * mult)  }
+
+    return mult
 end

--- a/Mods/ZyruviasIncremental/Tracking/Experience.lua
+++ b/Mods/ZyruviasIncremental/Tracking/Experience.lua
@@ -59,12 +59,18 @@ function ComputeCurrentSourceExpMult(source)
     if currentPrestige == 0 then
         return 1
     end
+    if source == nil then
+        DebugPrint { Text = "source is nil for EXP computation"}
+        return 1
+    end
     if ZyruIncremental.CachedExpMultipliersByGod[source] ~= nil then
         return ZyruIncremental.CachedExpMultipliersByGod[source]
     end
     local multiplier = 1
     for i, prestigeData in ipairs(ZyruIncremental.Data.PrestigeData) do
-        multiplier = multiplier * (prestigeData.ExperienceMulitpliers[source] or 1)
+        if prestigeData.ExperienceMulitpliers ~= nil then
+            multiplier = multiplier * (prestigeData.ExperienceMulitpliers[source] or 1)
+        end
     end
     ZyruIncremental.CachedExpMultipliersByGod[source] = multiplier
     return multiplier

--- a/Mods/ZyruviasIncremental/Tracking/Experience.lua
+++ b/Mods/ZyruviasIncremental/Tracking/Experience.lua
@@ -1,0 +1,47 @@
+local shrineExpFactorTable = {
+	EnemyDamageShrineUpgrade = 1.05,
+	HealingReductionShrineUpgrade = 1.05,
+	ShopPricesShrineUpgrade = 1.1,
+	EnemyCountShrineUpgrade = 1.02,
+	BossDifficultyShrineUpgrade = 1.1,
+
+	EnemyHealthShrineUpgrade = 1.05,
+	EnemyEliteShrineUpgrade = 1.15,
+	MinibossCountShrineUpgrade = 1.1,
+	ForceSellShrineUpgrade = 1.2,
+	EnemySpeedShrineUpgrade = 1.1,
+
+	TrapDamageShrineUpgrade = 1.05,
+	MetaUpgradeStrikeThroughShrineUpgrade = 1.2,
+	EnemyShieldShrineUpgrade = 1.02,
+	ReducedLootChoicesShrineUpgrade = 1.25,
+	BiomeSpeedShrineUpgrade = 1.05,
+	NoInvulnerabilityShrineUpgrade = 1,
+}
+
+function ZyruIncremental.ComputeShrinePactExperienceMultiplier(args)
+    args = args or {}
+    if args.Cached and ZyruIncremental.ShrinePactExperienceMultiplierCache ~= nil then
+        -- DebugPrint { Text = "returning cached shrine mult: " .. tostring(ZyruIncremental.ShrinePactExperienceMultiplierCache)}
+        return ZyruIncremental.ShrinePactExperienceMultiplierCache
+    end
+    local value = 1 -- multValue
+    local additiveValue = 1
+    local mixedValue = 1
+    for i, pactConditionName in ipairs(ShrineUpgradeOrder) do
+		local upgradeData = MetaUpgradeData[pactConditionName]
+        local expFactor = shrineExpFactorTable[pactConditionName]
+        local pactConditionCount = GetNumMetaUpgrades( pactConditionName ) or 0
+        if pactConditionCount > 0 then
+        
+            value = value * math.pow(expFactor, pactConditionCount)
+            additiveValue = additiveValue + (expFactor - 1) * pactConditionCount
+            mixedValue = mixedValue * ((expFactor - 1) * pactConditionCount + 1)
+        end
+
+        
+    end
+    -- DebugPrint { Text = "Mult: " .. tostring(value) ..  ", Mixed: " .. tostring(mixedValue) .. ", Additive: " .. tostring(additiveValue)}
+    ZyruIncremental.ShrinePactExperienceMultiplierCache = value
+    return mixedValue
+end

--- a/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
+++ b/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
@@ -967,19 +967,23 @@ function ZyruIncremental.GetExperienceFactor(traitName, damageValue, victim)
   local encounter = ModUtil.Path.Get("CurrentRun.CurrentRoom.Encounter")
     or ModUtil.Path.Get("CurrentRun.CurrentRoom.ChallengeEncounter")
 
+  -- multiplier increases
+  local heatMultiplier = ZyruIncremental.ComputeShrinePactExperienceMultiplier({ Cached = true })
+  multiplier = multiplier * heatMultiplier
+
   -- shrink multiplier by kill amount in survival rooms
   if encounter.EncounterType == "SurvivalChallenge" then
     local currentRoom = CurrentRun.CurrentRoom
     -- TODO: figure out correct caching of this
     if currentRoom.ZyruExpMult ~= nil then
-      multiplier = multiplier * math.max(0, 1 - 0.01 * currentKillCount)
+      multiplier = multiplier * math.max(0, 1 - 0.02 * currentKillCount)
     else
-      local currentKillMap = currentRoom.Kills
+      local currentKillMap = currentRoom.Kills or {}
       local currentKillCount = 0
       for name, count in pairs(currentKillMap) do
         currentKillCount = currentKillCount + count
       end
-      multiplier = multiplier * math.max(0, 1 - 0.01 * currentKillCount)
+      multiplier = multiplier * math.max(0, 1 - 0.02 * currentKillCount)
     end
   end
 

--- a/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
+++ b/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
@@ -62,7 +62,7 @@ ModUtil.Path.Wrap("GetRarityChances", function (baseFunc, args )
       godNameFromUpgrade = "Chaos"
     end
     local godData = ZyruIncremental.Data.GodData[godNameFromUpgrade]
-    baseRarity = baseRarity + (godData.RarityBonus or 0) + (ModUtil.Path.Get("TransientState[" ..godNameFromUpgrade .. "RarityBonus]", ZyruIncremental) or 0)
+    baseRarity = baseRarity + (godData.RarityBonus or 0) + (ModUtil.Path.Get("TransientState." ..godNameFromUpgrade .. "RarityBonus", ZyruIncremental) or 0)
 	end
 
 	local legendaryRoll = CurrentRun.Hero[referencedTable].LegendaryChance or 0

--- a/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
+++ b/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
@@ -1382,13 +1382,20 @@ end, ZyruIncremental)
 ---- DROP DATA SCALING
 -- TODO - ApplyConsumableItemResourceMultiplier wrap
 local getMaxHealthScalar = function ()
-  local level = ZyruIncremental.Data.DropData.RoomRewardMaxHealthDrop.Level or 0
-  return (1 + (level - 1) * 0.1)
+  if ModUtil.Path.Get("ZyruIncremental.Data.DropData.RoomRewardMaxHealthDrop.Level", 0) then
+    local level = ZyruIncremental.Data.DropData.RoomRewardMaxHealthDrop.Level or 0
+    return (1 + (level - 1) * 0.1)
+  end
+  return 1
 end
 
 local getCoinScalar = function ()
-  local level = ZyruIncremental.Data.DropData.RoomRewardMoneyDrop.Level or 0
-  return (1 + (level - 1) * 0.1)
+  if ModUtil.Path.Get("ZyruIncremental.Data.DropData.RoomRewardMoneyDrop.Level", 0) then
+    
+    local level = ZyruIncremental.Data.DropData.RoomRewardMoneyDrop.Level or 0
+    return (1 + (level - 1) * 0.1)
+  end
+  return 1
 end
 
 -- GetTotalHeroTraitValue tracking / mapping

--- a/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
+++ b/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
@@ -971,6 +971,9 @@ function ZyruIncremental.GetExperienceFactor(traitName, damageValue, victim)
   local heatMultiplier = ZyruIncremental.ComputeShrinePactExperienceMultiplier({ Cached = true })
   multiplier = multiplier * heatMultiplier
 
+  local godMultiplier = ComputeCurrentSourceExpMult(ZyruIncremental.BoonToGod[traitName])
+  multiplier = multiplier * godMultiplier
+
   -- shrink multiplier by kill amount in survival rooms
   if encounter.EncounterType == "SurvivalChallenge" then
     local currentRoom = CurrentRun.CurrentRoom

--- a/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
+++ b/Mods/ZyruviasIncremental/Tracking/ZyruIncrementalBoonTracking.lua
@@ -974,20 +974,17 @@ function ZyruIncremental.GetExperienceFactor(traitName, damageValue, victim)
   local godMultiplier = ComputeCurrentSourceExpMult(ZyruIncremental.BoonToGod[traitName])
   multiplier = multiplier * godMultiplier
 
-  -- shrink multiplier by kill amount in survival rooms
+  -- grow multiplier by kill amount in survival rooms
   if encounter.EncounterType == "SurvivalChallenge" then
     local currentRoom = CurrentRun.CurrentRoom
     -- TODO: figure out correct caching of this
-    if currentRoom.ZyruExpMult ~= nil then
-      multiplier = multiplier * math.max(0, 1 - 0.02 * currentKillCount)
-    else
-      local currentKillMap = currentRoom.Kills or {}
-      local currentKillCount = 0
-      for name, count in pairs(currentKillMap) do
-        currentKillCount = currentKillCount + count
-      end
-      multiplier = multiplier * math.max(0, 1 - 0.02 * currentKillCount)
+    local currentKillMap = currentRoom.Kills or {}
+    local currentKillCount = 0
+    for name, count in pairs(currentKillMap) do
+      currentKillCount = currentKillCount + count
     end
+    multiplier = multiplier * math.max(0.2, 0.02 * currentKillCount)
+
   end
 
   return multiplier

--- a/Mods/ZyruviasIncremental/UI/Framework.lua
+++ b/Mods/ZyruviasIncremental/UI/Framework.lua
@@ -178,12 +178,13 @@ ZyruIncremental.ScrollingList = {}
 
 ZyruIncremental.PauseBlockScreens = {}
 ModUtil.Path.Wrap("IsPauseBlocked", function (base)
-	for name  in pairs( ZyruIncremental.PauseBlockScreens ) do
-		if ActiveScreens[name] then
-			return true
-		end
-	end
-    return base()
+	-- for name  in pairs( ZyruIncremental.PauseBlockScreens ) do
+	-- 	if ActiveScreens[name] then
+	-- 		return true
+	-- 	end
+	-- end
+    return false
+    -- return base()
 end, ZyruIncremental)
 
 function GetScreenIdsToDestroy(screen) 

--- a/Mods/ZyruviasIncremental/UI/Framework.lua
+++ b/Mods/ZyruviasIncremental/UI/Framework.lua
@@ -890,18 +890,26 @@ function ZyruIncremental.RenderText(screen, component)
     -- Create Text
     textDefinition.Name = "BlankObstacle"
     local parentName = textDefinition.Parent or "Background"
-    textDefinition.Parent = parentName
     -- update a computed property on the object definition
     DebugPrint { Text = parentName }
     if screen.Components[parentName] == nil then
-        textDefinition.Parent = "Background"
+        parentName = "Background"
     end
-    textDefinition.DestinationId = screen.Components[textDefinition.Parent].Id
+    if screen.Components[parentName] == nil then
+        DebugPrint {
+            Text = "Attempting to bind text so something that doesn't exist: "
+                .. tostring(textDefinition.Parent) .. " to " .. parentName
+        }
+        return
+    end
+    
+    textDefinition.DestinationId = screen.Components[parentName].Id
 
 
     screen.Components[textDefinition.FieldName] = CreateScreenComponent(textDefinition)
     textDefinition.Id = screen.Components[textDefinition.FieldName].Id
     CreateTextBox(textDefinition)
+    textDefinition.Parent = parentName
     return textDefinition
 end
 

--- a/Mods/ZyruviasIncremental/UI/Framework.lua
+++ b/Mods/ZyruviasIncremental/UI/Framework.lua
@@ -178,8 +178,7 @@ ZyruIncremental.ScrollingList = {}
 
 ZyruIncremental.PauseBlockScreens = {}
 ModUtil.Path.Wrap("IsPauseBlocked", function (base)
-    if true then return false end
-	for name  in pairs( ZyruIncremental.PauseBlockScreens ) do
+	for name in pairs( ZyruIncremental.PauseBlockScreens ) do
 		if ActiveScreens[name] then
 			return true
 		end

--- a/Mods/ZyruviasIncremental/UI/Framework.lua
+++ b/Mods/ZyruviasIncremental/UI/Framework.lua
@@ -190,9 +190,13 @@ function GetScreenIdsToDestroy(screen)
     local idsToKeep = screen.PermanentComponents or {}
     local allIds = GetAllIds(screen.Components)
     local idsToDestroy = {}
-    for _, id in ipairs(allIds) do
+    for componentName, component in pairs(screen.Components) do
+        local id = component.Id
         if not Contains(idsToKeep, id) then
-            table.insert(idsToDestroy, id)
+            table.insert(idsToDestroy, component.Id)
+            -- remove the definition from the screen -- normally this is done
+            -- by just deleting the whole screen on close
+            screen.Components[componentName] = nil
         end
     end
     
@@ -211,11 +215,16 @@ function GoToPageFromSource(screen, button, args)
     RenderScreenPage(screen, button, button.PageIndex)
 end
 
+function DestroyTemporaryScreenComponents(screen)
+
+    Destroy({Ids = GetScreenIdsToDestroy(screen)})
+end
+
 -- Handles non-linear paging
 function RenderScreenPage(screen, button, index)
     -- Get Non-permanent components and DESTROY them
     screen.PageIndex = index
-    Destroy({Ids = GetScreenIdsToDestroy(screen, button)})
+    DestroyTemporaryScreenComponents(screen)
 
     -- then render it
     ZyruIncremental.RenderComponents(screen, screen.Pages[index], { Source = button })

--- a/Mods/ZyruviasIncremental/UI/Framework.lua
+++ b/Mods/ZyruviasIncremental/UI/Framework.lua
@@ -893,7 +893,11 @@ function ZyruIncremental.RenderText(screen, component)
     local parentName = textDefinition.Parent or "Background"
     textDefinition.Parent = parentName
     -- update a computed property on the object definition
-    textDefinition.DestinationId = screen.Components[parentName].Id
+    DebugPrint { Text = parentName }
+    if screen.Components[parentName] == nil then
+        textDefinition.Parent = "Background"
+    end
+    textDefinition.DestinationId = screen.Components[textDefinition.Parent].Id
 
 
     screen.Components[textDefinition.FieldName] = CreateScreenComponent(textDefinition)

--- a/Mods/ZyruviasIncremental/UI/Framework.lua
+++ b/Mods/ZyruviasIncremental/UI/Framework.lua
@@ -178,13 +178,12 @@ ZyruIncremental.ScrollingList = {}
 
 ZyruIncremental.PauseBlockScreens = {}
 ModUtil.Path.Wrap("IsPauseBlocked", function (base)
-	-- for name  in pairs( ZyruIncremental.PauseBlockScreens ) do
-	-- 	if ActiveScreens[name] then
-	-- 		return true
-	-- 	end
-	-- end
-    return false
-    -- return base()
+	for name  in pairs( ZyruIncremental.PauseBlockScreens ) do
+		if ActiveScreens[name] then
+			return true
+		end
+	end
+    return base()
 end, ZyruIncremental)
 
 function GetScreenIdsToDestroy(screen) 

--- a/Mods/ZyruviasIncremental/UI/Framework.lua
+++ b/Mods/ZyruviasIncremental/UI/Framework.lua
@@ -378,7 +378,7 @@ function ZyruIncremental.CreateMenu(name, args)
     local components = screen.Components
 
     -- initialize group if provided
-    screen.Group = screen.Group or "Combat_Menu_TraitTray_Overlay"
+    -- screen.Group = screen.Group or "Combat_Menu_TraitTray_Overlay"
     -- initialize screen page history
     screen.PageStack = { }
 

--- a/Mods/ZyruviasIncremental/UI/Framework.lua
+++ b/Mods/ZyruviasIncremental/UI/Framework.lua
@@ -178,6 +178,7 @@ ZyruIncremental.ScrollingList = {}
 
 ZyruIncremental.PauseBlockScreens = {}
 ModUtil.Path.Wrap("IsPauseBlocked", function (base)
+    if true then return false end
 	for name  in pairs( ZyruIncremental.PauseBlockScreens ) do
 		if ActiveScreens[name] then
 			return true
@@ -805,8 +806,11 @@ end
 function ZyruIncremental.RenderDropdown(screen, component)
     local dropdownDefinition = GetComponentDefinition(screen, component)
     dropdownDefinition.Name = dropdownDefinition.FieldName
-    
-    ZyruIncremental.Dropdown.CreateDropdown(screen, dropdownDefinition)
+    local dropdown = ZyruIncremental.Dropdown.CreateDropdown(screen, dropdownDefinition)
+    if dropdownDefinition.Disabled then
+        dropdown.isEnabled = false
+        UseableOff{ Id = dropdown.Id }
+    end
 end
 
 function ZyruIncremental.RenderButton(screen, component)

--- a/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
+++ b/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
@@ -174,16 +174,16 @@ ModUtil.Path.Wrap("CloseRunClearScreen", function (baseFunc, ...)
                 {
                     Type = "Text",
                     SubType = "Title",
+                    FieldName = "BoonProgressionTitle",
                     Args = {
-                        FieldName = "BoonProgressionTitle",
                         Text = "Boon Progression"
                     }
                 },
                 {
                     Type = "Text",
                     SubType = "Subtitle",
+                    FieldName = "BoonProgressionSubtitle",
                     Args = {
-                        FieldName = "BoonProgressionSubtitle",
                         Text = "Wow, you sure used some boons today Zagreus."
                     }
                 }
@@ -573,8 +573,8 @@ function ShowZyruRamblingMenu()
             {
                 Type = "Text",
                 SubType = "Title",
+                FieldName = "MenuTitle",
                 Args = {
-                    FieldName = "MenuTitle",
                     Text = "FAQ / Tutorial / Roadmap",
                 },
             },
@@ -588,16 +588,16 @@ function ShowZyruRamblingMenu()
                 {
                     Type = "Text",
                     SubType = "Subtitle",
+                    FieldName = "TutorialRamblingsText",
                     Args = {
                         Text = "Frequently Asked Questions and Basic Explanations for this weird-ass mod by a weird-ass modder",
-                        FieldName = "TutorialRamblingsText",
                     }
                 },
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "TutorialText",
                     Args = {
-                        FieldName = "TutorialText",
                         Text = 
                             "How do I gain experience for my booons? \\n Use your boons! It's that easy. If a boon does damage, deal damage with it equipped" ..
                             " to gain experience. If it applies an extra effect to enemies, apply that effect to enemies to get some activation experience! " .. 
@@ -622,16 +622,16 @@ function ShowZyruRamblingMenu()
                 {
                     Type = "Text",
                     SubType = "Subtitle",
+                    FieldName = "TutorialRamblingsText2",
                     Args = {
                         Text = "Frequently Asked Questions and Basic Explanations for this weird-ass mod by a weird-ass modder",
-                        FieldName = "TutorialRamblingsText2",
                     }
                 },
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "TutorialText2",
                     Args = {
-                        FieldName = "TutorialText2",
                         Text = 
                             "What's the point? \\n It's an incremental game, honey. Numbers go up, pump dopamine straight into the veins. Simple as. \\n\\n "..
 
@@ -655,16 +655,16 @@ function ShowZyruRamblingMenu()
                 {
                     Type = "Text",
                     SubType = "Subtitle",
+                    FieldName = "RoadmapText",
                     Args = {
                         Text = "Roadmap",
-                        FieldName = "RoadmapText",
                     }
                 },
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "RoadmapText1",
                     Args = {
-                        FieldName = "RoadmapText1",
                         Text = 
                             "1.0.0 - Initial Release \\n Primary changes: 5 new tiers of boon rarity added, with a new rarity distribution system. "..
                             " New set of unlockable Duo Boons between Olympians and Hermes. New Olympian Legendary Boons. Boon Experience system that "..
@@ -685,8 +685,8 @@ function ShowZyruRamblingMenu()
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "RoadmapText2",
                     Args = {
-                        FieldName = "RoadmapText2",
                         Text = "This Page Is Intentionally Left Blank",
                     }
                 },
@@ -706,24 +706,24 @@ function ShowZyruSettingsMenu()
             {
                 Type = "Text",
                 SubType = "Title",
+                FieldName = "MenuTitle",
                 Args = {
-                    FieldName = "MenuTitle",
                     Text = "Mod Settings",
                 },
             },
             {
                 Type = "Text",
                 SubType = "Subtitle",
+                FieldName = "WelcomeTitle",
                 Args = {
                     Text = "Change mod configurations according to your heart's desires.",
-                    FieldName = "WelcomeTitle",
                 }
             },
             {
                 Type = "Dropdown",
                 SubType = "Standard",
+                FieldName = "DifficultyDropdown",
                 Args = {
-                    FieldName = "DifficultyDropdown",
                     Group = "DifficultyGroup",
                     -- X, Y, Items, Name
                     X = ScreenWidth / 6,
@@ -760,8 +760,8 @@ function ShowZyruSettingsMenu()
             {
                 Type = "Text",
                 SubType = "Paragraph",
+                FieldName = "ExpDropText",
                 Args = {
-                    FieldName = "ExpDropText",
                     Text = "Configure EXP popup behavior",
                     OffsetX = - ScreenWidth / 4 + 100,
                     OffsetY = - ScreenHeight / 6 - 25,
@@ -771,8 +771,8 @@ function ShowZyruSettingsMenu()
             {
                 Type = "Dropdown",
                 SubType = "Standard",
+                FieldName = "LevelUpSettingDropdown",
                 Args = {
-                    FieldName = "LevelUpSettingDropdown",
                     Group = "LevelupGroup",
                     -- X, Y, Items, Name
                     X = ScreenWidth / 6,
@@ -821,8 +821,8 @@ function ShowZyruSettingsMenu()
             {
                 Type = "Text",
                 SubType = "Paragraph",
+                FieldName = "LevelupText",
                 Args = {
-                    FieldName = "LevelupText",
                     Text = "Configure Level-up notification behavior",
                     OffsetX = - ScreenWidth / 4 + 100,
                     OffsetY = - 145,
@@ -843,8 +843,8 @@ function ModInitializationScreenUpdateDifficultyText(screen, text)
     ZyruIncremental.UpdateText(screen, {
         Type = "Text",
         SubType = "Paragraph",
+        FieldName = "DifficultyDropdownSelectedText",
         Args = {
-            FieldName = "DifficultyDropdownSelectedText",
             Text = "Difficulty Selected: " .. text,
         }
     })
@@ -854,8 +854,8 @@ function ModInitializationScreenUpdateStartingPointText(screen, text)
     ZyruIncremental.UpdateText(screen, {
         Type = "Text",
         SubType = "Paragraph",
+        FieldName = "StartingPointDropdownSelectedText",
         Args = {
-            FieldName = "StartingPointDropdownSelectedText",
             Text = "Starting Point Selected: " .. text,
             OffsetY = - ScreenHeight / 6 -25,
             Justification = "Left",
@@ -868,24 +868,24 @@ function CreateAcknowledgementsPage()
         {
             Type = "Text",
             SubType = "Subtitle",
+            FieldName = "AcknowledgementsTitle",
             Args = {
-                FieldName = "AcknowledgementsTitle",
                 Text = "Acknowledgements"
             }
         },
         {
             Type = "Text",
             SubType = "Paragraph",
+            FieldName = "ContextText",
             Args = {
-                FieldName = "ContextText",
                 Text = "A giant thanks to all the support I've gotten over the development of this mod, whether emotional or technical. I love you all."
             }
         },
         {
             Type = "Text",
             SubType = "Paragraph",
+            FieldName = "AcknowledgementsColumn1",
             Args = {
-                FieldName = "AcknowledgementsColumn1",
                 OffsetY = -200,
                 Width = ScreenWidth * 0.4,
                 Text = 
@@ -907,8 +907,8 @@ function CreateAcknowledgementsPage()
         {
             Type = "Text",
             SubType = "Paragraph",
+            FieldName = "AcknowledgementsColumn3",
             Args = {
-                FieldName = "AcknowledgementsColumn3",
                 OffsetY = -200,
                 Width = ScreenWidth * 0.17,
                 OffsetX = - ScreenWidth * 0.2,
@@ -927,8 +927,8 @@ function CreateAcknowledgementsPage()
         {
             Type = "Text",
             SubType = "Paragraph",
+            FieldName = "AcknowledgementsColumn2",
             Args = {
-                FieldName = "AcknowledgementsColumn2",
                 OffsetY = -200,
                 Width = ScreenWidth * 0.4,
                 OffsetX = 0,
@@ -951,24 +951,24 @@ function ModInitializationScreen2()
                 {
                     Type = "Text",
                     SubType = "Title",
+                    FieldName = "MenuTitle",
                     Args = {
-                        FieldName = "MenuTitle",
                         Text = "Incremental Mod Setup",
                     },
                 },
                     {
                         Type = "Text",
                         SubType = "Subtitle",
+                        FieldName = "WelcomeTitle",
                         Args = {
                             Text = "Existing Save Detected",
-                            FieldName = "WelcomeTitle",
                         }
                     },
                     {
                         Type = "Text",
                         SubType = "Paragraph",
+                        FieldName = "WelcomeText",
                         Args = {
-                            FieldName = "WelcomeText",
                             Text = "Hello there,\\n\\n In order to use this mod, you must start a new save file. Your current"
                             .." savefile progress does not translate well in the new mod systems, so it does not make sense to"
                             .." allow you to continue. Please select \"Give Up\" or \"Quit\" and create a new file to access the mod setup page and begin your "
@@ -986,16 +986,16 @@ function ModInitializationScreen2()
                 {
                     Type = "Text",
                     SubType = "Subtitle",
+                    FieldName = "WelcomeTitle",
                     Args = {
                         Text = "Welcome",
-                        FieldName = "WelcomeTitle",
                     }
                 },
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "WelcomeText",
                     Args = {
-                        FieldName = "WelcomeText",
                         Text = "Welcome to the Incremental Overhaul Mod. The game has been transformed from a roguelike"
                         .." with primary emphasis on single runs to large, long term emphasis on metaprogression, unlocks,"
                         .." practice, and various other points of focus of the Incremental game genre. Please understand that"
@@ -1010,16 +1010,16 @@ function ModInitializationScreen2()
                 {
                     Type = "Text",
                     SubType = "Subtitle",
+                    FieldName = "ContextTitle",
                     Args = {
-                        FieldName = "ContextTitle",
                         Text = "Story Context"
                     }
                 },
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "ContextText",
                     Args = {
-                        FieldName = "ContextText",
                         Text = "When you finally resolve the plot of Hades for the first time, you "
                         .."agree to continue traversing through the underworld more-or-less as a "
                         .."glorified security analyst. Through your further battles in Tartarus, Asphodel, "
@@ -1042,24 +1042,24 @@ function ModInitializationScreen2()
                 {
                     Type = "Text",
                     SubType = "Subtitle",
+                    FieldName = "DifficultyTitle",
                     Args = {
-                        FieldName = "DifficultyTitle",
                         Text = "Difficulty Settings"
                     }
                 },
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "DifficultyText",
                     Args = {
-                        FieldName = "DifficultyText",
                         Text = "This mod is intended to be difficult by nature of infinite scaling and building off the original game's innate difficulty. Please select your preferred difficulty settings below."
                     }
                 },
                 {
                     Type = "Dropdown",
                     SubType = "Standard",
+                    FieldName = "DifficultyDropdown",
                     Args = {
-                        FieldName = "DifficultyDropdown",
                         Group = "DifficultyGroup",
                         -- X, Y, Items, Name
                         X = ScreenWidth / 6,
@@ -1103,8 +1103,8 @@ function ModInitializationScreen2()
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "DifficultyDropdownSelectedText",
                     Args = {
-                        FieldName = "DifficultyDropdownSelectedText",
                         Text = "Difficulty Selected: " .. (ZyruIncremental.Data.FileOptions.DifficultySetting or "Standard"),
                         OffsetY = - ScreenHeight / 6 - 25,
                         Justification = "Left",
@@ -1113,8 +1113,8 @@ function ModInitializationScreen2()
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "DifficultyExplanation",
                     Args = {
-                        FieldName = "DifficultyExplanation",
                         Text = "Standard - The originally intended difficulty by the developer (that's me!! lmao) - enemies grow in strength "
                         .."and health, and a few other challenges sneak their way in throughout the course of gameplay. \\n\\n "
                         
@@ -1138,16 +1138,16 @@ function ModInitializationScreen2()
                 {
                     Type = "Text",
                     SubType = "Subtitle",
+                    FieldName = "StartingPointTitle",
                     Args = {
-                        FieldName = "StartingPointTitle",
                         Text = "Starting Point Settings"
                     }
                 },
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "StartingPointText",
                     Args = {
-                        FieldName = "StartingPointText",
                         Text = "This mod requires you to start a fresh file since the context of game progression in normal "
                         .."Hades does not make sense in the context of this mod. However, that does not mean you have to complete "
                         .."the whole story again. You are free to start a fresh file and re-experience the story, but you may "
@@ -1157,8 +1157,8 @@ function ModInitializationScreen2()
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "StartingPointDropdownSelectedText",
                     Args = {
-                        FieldName = "StartingPointDropdownSelectedText",
                         Text = "Starting Point Selected: " .. 
                             (ZyruIncremental.Data.FileOptions.StartingPoint or ZyruIncremental.Constants.SaveFile.EPILOGUE),
                         OffsetY = - ScreenHeight / 6 + 25,
@@ -1168,8 +1168,8 @@ function ModInitializationScreen2()
                 {
                     Type = "Dropdown",
                     SubType = "Standard",
+                    FieldName = "StartingPointDropdown",
                     Args = {
-                        FieldName = "StartingPointDropdown",
                         Group = "bleh",
                         X = ScreenWidth / 2,
                         Y = ScreenHeight / 2,
@@ -1202,16 +1202,16 @@ function ModInitializationScreen2()
                 {
                     Type = "Text",
                     SubType = "Subtitle",
+                    FieldName = "finishedTitle",
                     Args = {
                         Text = "Final Step",
-                        FieldName = "finishedTitle"
                     }
                 },
                 {
                     Type = "Text",
                     SubType = "Paragraph",
+                    FieldName = "FinishedText",
                     Args = {
-                        FieldName = "FinishedText",
                         Text = "Click the button below to finish your file configuration. Please note that if you are "
                         .."starting from the Epilogue file setting, it will take a minute to process save file changes. "
                         .."Additionally, there are extra miscellaneous settings in the Courtyard when you get there."
@@ -1222,14 +1222,14 @@ function ModInitializationScreen2()
                 {
                     Type = "Button",
                     SubType = "Basic",
+                    FieldName = "FinishedFileConfiguration",
                     Args = {
                         Scale = 1.0,
-                        FieldName = "FinishedFileConfiguration",
                         Label = {
                             Type = "Text",
                             SubType = "Paragraph",
+                            FieldName = "FinishedFileConfigurationText",
                             Args = {
-                                FieldName = "FinishedFileConfigurationText",
                                 Text = "Finish",
                                 FontSize = "30",
                                 OffsetY = 0,
@@ -1250,8 +1250,8 @@ function ModInitializationScreen2()
             {
                 Type = "Text",
                 SubType = "Title",
+                FieldName = "MenuTitle",
                 Args = {
-                    FieldName = "MenuTitle",
                     Text = "Incremental Mod Setup",
                 }
             }
@@ -1377,8 +1377,8 @@ function CloseInitializationScreen(screen, button)
     local progressBar = {
         Type = "ProgressBar",
         SubType = "Standard",
+        FieldName = "SaveStateBar",
         Args = {
-            FieldName = "SaveStateBar",
             X = ScreenCenterX - 480 * 1.5,
             ScaleX = 3,
             ScaleY = 3,
@@ -1387,8 +1387,8 @@ function CloseInitializationScreen(screen, button)
     local progressText = {
         Type = "Text",
         SubType = "Paragraph",
+        FieldName = "SaveStateText",
         Args = {
-            FieldName = "SaveStateText",
             Text = "",
             OffsetY = -100,
             OffsetX = 0,
@@ -1478,8 +1478,8 @@ end, ZyruIncremental)
 --             {
 --                 Type = "Button",
 --                 SubType = "Icon",
---                 Args = {
 --                     FieldName = "IconTest",
+--                 Args = {
 --                     Group = "Combat_Menu_TraitTray",
 --                     Animation = "Codex_Portrait_Zagreus",
 --                     OffsetX = 0,
@@ -1507,8 +1507,8 @@ function UpdateBoonInfoProgressScreen(screen, boonName)
     ZyruIncremental.UpdateComponent(screen, {
         Type = "Text",
         SubType = "Subtitle",
+        FieldName = "BoonProgressSubtitle",
         Args = {
-            FieldName = "BoonProgressSubtitle",
             Text = boonName
         }
 
@@ -1517,8 +1517,8 @@ function UpdateBoonInfoProgressScreen(screen, boonName)
     ZyruIncremental.UpdateComponent(screen, {
         Type = "Icon",
         SubType = "Standard",
+        FieldName = "BoonProgressBoonIcon",
         Args = {
-            FieldName = "BoonProgressBoonIcon",
             Animation = GetTraitIcon( TraitData[boonName] or {} ),
             Scale = 2.0
         }
@@ -1528,8 +1528,8 @@ function UpdateBoonInfoProgressScreen(screen, boonName)
     local boonLevelLabel = {
         Type = "Text",
         SubType = "Note",
+        FieldName = "BoonLevelUniqueLabel",
         Args = {
-            FieldName = "BoonLevelUniqueLabel",
             X = ScreenCenterX + ScreenWidth / 6 - 480 * 0.75,
             Y = ScreenCenterY - 120,
             Text = "Boon Level",
@@ -1550,8 +1550,8 @@ function UpdateBoonInfoProgressScreen(screen, boonName)
     ZyruIncremental.UpdateProgressBar(screen, {
         Type = "ProgressBar",
         SubType = "Standard",
+        FieldName = "BoonProgressBar",
         Args = {
-            FieldName = "BoonProgressBar",
             BackgroundColor = {96, 96, 96, 255}, -- Default color.
             ForegroundColor = {255, 255, 255, 255},
             Proportion = 0,
@@ -1569,8 +1569,8 @@ function UpdateBoonInfoProgressScreen(screen, boonName)
     ZyruIncremental.UpdateProgressBar(screen, {
         Type = "ProgressBar",
         SubType = "Standard",
+        FieldName = "BoonProgressBar",
         Args = {
-            FieldName = "BoonProgressBar",
             Proportion = expProportion,
             UpdateDuration = 1,
             X = ScreenCenterX + ScreenWidth / 6 - 480 * 0.75,
@@ -1616,8 +1616,8 @@ function ShowGodProgressScreen(screen, button)
         {
             Type = "Text",
             SubType = "Title",
+            FieldName = button.PageIndex .. "ProgressTitle",
             Args = {
-                FieldName = button.PageIndex .. "ProgressTitle",
                 Text = button.PageIndex, -- todo: generalize args or properties or something??
             }
         },
@@ -1633,9 +1633,9 @@ function ShowGodProgressScreen(screen, button)
         {
             Type = "Text",
             SubType = "Subtitle",
+            FieldName = "BoonProgressSubtitle",
             Args = {
                 OffsetX = ScreenWidth / 6,
-                FieldName = "BoonProgressSubtitle",
                 Text = ""
             }
         },
@@ -1643,8 +1643,8 @@ function ShowGodProgressScreen(screen, button)
         {
             Type = "Icon",
             SubType = "Standard",
+            FieldName = "BoonProgressBoonIcon",
             Args = {
-                FieldName = "BoonProgressBoonIcon",
                 OffsetX = ScreenWidth / 3,
                 OffsetY = -250,
                 Scale = 2,
@@ -1654,8 +1654,8 @@ function ShowGodProgressScreen(screen, button)
         {
             Type = "ProgressBar",
             SubType = "Standard",
+            FieldName = "BoonProgressBar",
             Args = {
-                FieldName = "BoonProgressBar",
                 X = ScreenCenterX + ScreenWidth / 6 - 480 * 0.75,
                 Y = ScreenCenterY - 90,
                 -- BackgroundColor = {0, 0, 0, 0},
@@ -1692,8 +1692,8 @@ function ZyruIncremental.ShowGodProgressUI(screen, button)
     local rarityBarLabel = {
         Type = "Text",
         SubType = "Note",
+        FieldName = "DistributionLabel",
         Args = {
-            FieldName = "DistributionLabel",
             X = ScreenCenterX + ScreenWidth / 6 - 480 * 0.75,
             Y = ScreenCenterY + ScreenHeight / 6 - 150,
             Text = "Rarity Bonus: " .. (100 + ZyruIncremental.ComputeRarityBonusForGod(button.PageIndex)) .. "% \\n Boons' Offered Rarity Distribution",
@@ -1705,8 +1705,8 @@ function ZyruIncremental.ShowGodProgressUI(screen, button)
     local rarityBarComponent = {
         Type = "Distribution",
         SubType = "Standard",
+        FieldName = "RarityDistributionBar",
         Args = {
-            FieldName = "RarityDistributionBar",
             BackgroundColor = {96, 96, 96, 255}, -- Default color.
             ForegroundColor = {255, 255, 255, 255},
             X = ScreenCenterX + ScreenWidth / 6 - 480 * 0.75,
@@ -1725,8 +1725,8 @@ function ZyruIncremental.ShowGodProgressUI(screen, button)
     local godLevelLabel = {
         Type = "Text",
         SubType = "Note",
+        FieldName = "GodLevelLabel",
         Args = {
-            FieldName = "GodLevelLabel",
             X = ScreenCenterX + ScreenWidth / 6 - 480 * 0.75,
             Y = ScreenCenterY + ScreenHeight / 6 + 100,
             Text = button.PageIndex .. "'s God Level",
@@ -1747,8 +1747,8 @@ function ZyruIncremental.ShowGodProgressUI(screen, button)
     ZyruIncremental.CreateOrUpdateComponent(screen, {
         Type = "ProgressBar",
         SubType = "Standard",
+        FieldName = "GodProgressBar",
         Args = {
-            FieldName = "GodProgressBar",
             BackgroundColor = {96, 96, 96, 255}, -- Default color.
             ForegroundColor = {255, 255, 255, 255},
             Proportion = 0,
@@ -1766,8 +1766,8 @@ function ZyruIncremental.ShowGodProgressUI(screen, button)
     ZyruIncremental.UpdateProgressBar(screen, {
         Type = "ProgressBar",
         SubType = "Standard",
+        FieldName = "GodProgressBar",
         Args = {
-            FieldName = "GodProgressBar",
             BackgroundColor = {96, 96, 96, 255}, -- Default color.
             ForegroundColor = {255, 255, 255, 255},
             Proportion = expProportion,
@@ -1793,16 +1793,16 @@ function ShowZyruProgressScreen()
         {
             Type = "Text",
             SubType = "Title",
+            FieldName = "ProgressTitle",
             Args = {
-                FieldName = "ProgressTitle",
                 Text = "Incremental Progress",
             }
         },
         {
             Type = "Text",
             SubType = "Subtitle",
+            FieldName = "ProgressSubtitle",
             Args = {
-                FieldName = "ProgressSubtitle",
                 Text = "Click on a God's portrait to see your progress with their gifts!",
             }
         },
@@ -1815,8 +1815,8 @@ function ShowZyruProgressScreen()
         table.insert(componentsToRender, {
             Type = "Button",
             SubType = "Icon",
+            FieldName = name .. "Button",
             Args = {
-                FieldName = name .. "Button",
                 Animation = "Codex_Portrait_" .. name,
                 -- series layout
                 OffsetX = - ScreenWidth / 2 + ScreenWidth / 11 * i,
@@ -1852,16 +1852,16 @@ function ShowZyruUpgradeScreen()
         {
             Type = "Text",
             SubType = "Title",
+            FieldName = "UpgradeTitle",
             Args = {
-                FieldName = "UpgradeTitle",
                 Text = "Olympian Upgrades",
             }
         },
         {
             Type = "Text",
             SubType = "Subtitle",
+            FieldName = "UpgradeSubtitle",
             Args = {
-                FieldName = "UpgradeSubtitle",
                 Text = "Click on a God's portrait to see additional gifts and bonuses they can offer!",
             }
         },
@@ -1874,8 +1874,8 @@ function ShowZyruUpgradeScreen()
         table.insert(componentsToRender, {
             Type = "Button",
             SubType = "Icon",
+            FieldName = name .. "Button",
             Args = {
-                FieldName = name .. "Button",
                 Animation = "Codex_Portrait_" .. name,
                 -- series layout
                 OffsetX = - ScreenWidth / 2 + ScreenWidth / 10 * i,
@@ -1925,8 +1925,8 @@ function UpdateUpgradeInfoScreen(screen, upgrade, button)
     ZyruIncremental.CreateOrUpdateComponent(screen, {
         Type = "Icon",
         SubType = "Standard",
+        FieldName = "UpgradeIcon",
         Args = {
-            FieldName = "UpgradeIcon",
             Animation = GetTraitIcon( TraitData[upgrade.Name] or {} ),
             OffsetX = ScreenWidth / 6,
             OffsetY = -100,
@@ -1936,8 +1936,8 @@ function UpdateUpgradeInfoScreen(screen, upgrade, button)
     ZyruIncremental.CreateOrUpdateComponent(screen, {
         Type = "Text",
         SubType = "Note",
+        FieldName = "UpgradeCurrencyText",
         Args = {
-            FieldName = "UpgradeCurrencyText",
             OffsetX = ScreenWidth / 3 - 50,
             OffsetY = -450,
             Justification = "Right",
@@ -1948,8 +1948,8 @@ function UpdateUpgradeInfoScreen(screen, upgrade, button)
     ZyruIncremental.CreateOrUpdateComponent(screen, {
         Type = "Text",
         SubType = "Paragraph",
+        FieldName = "UpgradeDescriptionText",
         Args = {
-            FieldName = "UpgradeDescriptionText",
             Text = "",
             OffsetX = ScreenWidth / 6,
             OffsetY = 0,
@@ -1959,8 +1959,8 @@ function UpdateUpgradeInfoScreen(screen, upgrade, button)
     ZyruIncremental.CreateOrUpdateComponent(screen, {
         Type = "Text",
         SubType = "Note",
+        FieldName = "UpgradeCostText",
         Args = {
-            FieldName = "UpgradeCostText",
             Text = GetUpgradeGostText(upgrade),
             OffsetX = ScreenWidth / 6,
             OffsetY = 110,
@@ -1971,8 +1971,8 @@ function UpdateUpgradeInfoScreen(screen, upgrade, button)
     ZyruIncremental.CreateOrUpdateComponent(screen, {
         Type = "Button",
         SubType = "Basic",
+        FieldName = "PurchaseButton",
         Args = {
-            FieldName = "PurchaseButton",
             OffsetX = ScreenWidth / 6,
             OffsetY = 200,
             Label = "Purchase Upgrade",
@@ -2046,8 +2046,8 @@ function ShowGodUpgradeScreen(screen, button)
         {
             Type = "Text",
             SubType = "Title",
+            FieldName = source .. "UpgradeTitle",
             Args = {
-                FieldName = source .. "UpgradeTitle",
                 Text = source, -- todo: generalize args or properties or something??
             }
         },
@@ -2063,8 +2063,8 @@ function ShowGodUpgradeScreen(screen, button)
         {
             Type = "Icon",
             SubType = "Standard",
+            FieldName = "UpgradeCurrency",
             Args = {
-                FieldName = "UpgradeCurrency",
                 OffsetX = ScreenWidth / 3,
                 OffsetY = -450,
                 Scale = 0.75,
@@ -2074,8 +2074,8 @@ function ShowGodUpgradeScreen(screen, button)
         {
             Type = "Text",
             SubType = "Note",
+            FieldName = "UpgradeCurrencyText",
             Args = {
-                FieldName = "UpgradeCurrencyText",
                 OffsetX = ScreenWidth / 3 - 50,
                 OffsetY = -450,
                 Justification = "Right",

--- a/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
+++ b/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
@@ -2090,3 +2090,93 @@ function ShowGodUpgradeScreen(screen, button)
     }
     ZyruIncremental.RenderComponents(screen, componentsToRender)
 end
+
+-- 1.1.0 EXP stuff
+ModUtil.Path.Wrap("OpenShrineUpgradeMenu", function (base, args)
+    -- base calls "HandleScreenInput" unthreaded which blocks our function
+    thread(base, args)
+
+    
+	local screen = ScreenAnchors.ShrineScreen
+    local components = screen.Components
+    ZyruIncremental.CreateOrUpdateComponent(screen, {
+        Type = "Text",
+        SubType = "Note",
+        FieldName = "ExpCounter",
+        Args = {
+            Text = "Exp Multiplier: x" .. string.format("%.2f", ZyruIncremental.ComputeShrinePactExperienceMultiplier()),
+            Parent = "ShopBackground",
+            Group = "Combat_Menu",
+            Font = "AlegreyaSansSCExtraBold",
+            FontSize = 24,
+            OffsetY = -345,
+            Color = Color.White,
+            OffsetX = 200,
+        }
+    })
+end, ZyruIncremental)
+
+local shrineExpFactorTable = {
+	EnemyDamageShrineUpgrade = 1.05,
+	HealingReductionShrineUpgrade = 1.05,
+	ShopPricesShrineUpgrade = 1.1,
+	EnemyCountShrineUpgrade = 1.02,
+	BossDifficultyShrineUpgrade = 1.1,
+
+	EnemyHealthShrineUpgrade = 1.05,
+	EnemyEliteShrineUpgrade = 1.15,
+	MinibossCountShrineUpgrade = 1.1,
+	ForceSellShrineUpgrade = 1.2,
+	EnemySpeedShrineUpgrade = 1.1,
+
+	TrapDamageShrineUpgrade = 1.05,
+	MetaUpgradeStrikeThroughShrineUpgrade = 1.2,
+	EnemyShieldShrineUpgrade = 1.02,
+	ReducedLootChoicesShrineUpgrade = 1.25,
+	BiomeSpeedShrineUpgrade = 1.05,
+	NoInvulnerabilityShrineUpgrade = 1,
+}
+function ZyruIncremental.ComputeShrinePactExperienceMultiplier(args)
+    if args.Cached and ZyruIncremental.ShrinePactExperienceMultiplierCache ~= nil then
+        -- DebugPrint { Text = "returning cached shrine mult: " .. tostring(ZyruIncremental.ShrinePactExperienceMultiplierCache)}
+        return ZyruIncremental.ShrinePactExperienceMultiplierCache
+    end
+    local value = 1 -- multValue
+    local additiveValue = 1
+    local mixedValue = 1
+    for i, pactConditionName in ipairs(ShrineUpgradeOrder) do
+		local upgradeData = MetaUpgradeData[pactConditionName]
+        local expFactor = shrineExpFactorTable[pactConditionName]
+        local pactConditionCount = GetNumMetaUpgrades( pactConditionName ) or 0
+        if pactConditionCount > 0 then
+        
+            value = value * math.pow(expFactor, pactConditionCount)
+            additiveValue = additiveValue + (expFactor - 1) * pactConditionCount
+            mixedValue = mixedValue * ((expFactor - 1) * pactConditionCount + 1)
+        end
+
+        
+    end
+    -- DebugPrint { Text = "Mult: " .. tostring(value) ..  ", Mixed: " .. tostring(mixedValue) .. ", Additive: " .. tostring(additiveValue)}
+    ZyruIncremental.ShrinePactExperienceMultiplierCache = value
+    return value
+end
+function ZyruIncremental.UpdateShrineExperienceMultiplier(screen, button)
+
+    ZyruIncremental.CreateOrUpdateComponent(screen, {
+        Type = "Text",
+        SubType = "Note", 
+        FieldName = "ExpCounter",
+        Args = {
+            Text = "Exp Multiplier: x" .. string.format("%.2f", ZyruIncremental.ComputeShrinePactExperienceMultiplier()),
+        }
+    })
+end
+
+ModUtil.Path.Wrap("HandleMetaUpgradeInput", function (base, screen, button)
+
+    base(screen, button)
+
+    ZyruIncremental.UpdateShrineExperienceMultiplier(screen, button)
+
+end, ZyruIncremental)

--- a/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
+++ b/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
@@ -1397,8 +1397,8 @@ function CloseInitializationScreen(screen, button)
             
         }
     }
-    ZyruIncremental.RenderComponent(screen, progressBar)
-    ZyruIncremental.RenderComponent(screen, progressText)
+    ZyruIncremental.CreateOrUpdateComponent(screen, progressBar)
+    ZyruIncremental.CreateOrUpdateComponent(screen, progressText)
 
     for _, stage in ipairs(stages) do
         if stage.Voicelines then

--- a/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
+++ b/Mods/ZyruviasIncremental/UI/ZyruIncrementalUI.lua
@@ -354,19 +354,73 @@ function CloseScreenByName ( name )
 	OnScreenClosed({ Flag = screen.Name })
 end
 
+ModUtil.Path.Wrap("ShowOverlookText", function (base)
+    if IsScreenOpen("ZyruResetScreen") then
+        return
+    end
+    base()
+end, ZyruIncremental)
+
 -- Courtyard Progress Screen
 function ShowZyruResetScreen ()
-    CreateAnimation({ Name = "ItemGet_PomUpgraded", DestinationId = CurrentRun.Hero.ObjectId, Scale = 2.0 })
-    thread( InCombatTextArgs, {
-        TargetId = CurrentRun.Hero.ObjectId,
-        Text = "Coming Soon!",
-        SkipRise = false,
-        SkipFlash = true,
-        ShadowScale = 0.66,
-        Duration = 1.5,
-        OffsetY = -100 })
-    offsetY = offsetY - 60
-    thread(PlayVoiceLines, GlobalVoiceLines.InvalidResourceInteractionVoiceLines)
+    -- CreateAnimation({ Name = "ItemGet_PomUpgraded", DestinationId = CurrentRun.Hero.ObjectId, Scale = 2.0 })
+    -- thread( InCombatTextArgs, {
+    --     TargetId = CurrentRun.Hero.ObjectId,
+    --     Text = "Coming Soon!",
+    --     SkipRise = false,
+    --     SkipFlash = true,
+    --     ShadowScale = 0.66,
+    --     Duration = 1.5,
+    --     OffsetY = -100 })
+    -- offsetY = offsetY - 60
+    -- thread(PlayVoiceLines, GlobalVoiceLines.InvalidResourceInteractionVoiceLines)
+
+    local screen = ZyruIncremental.CreateMenu("ZyruResetScreen", {
+        Components = {
+            {
+                Type = "Text",
+                SubType = "Title",
+                FieldName = "ResetTitle",
+                Args = {
+                    Text = "Do you want to go back to an easier time?",
+                    FontSize = 24,
+                }
+            },
+            {
+                Type = "Button",
+                SubType = "Back"
+            },
+        },
+        Pages = {
+            [1] = {
+                    {
+                        Type = "Text",
+                        SubType = "Paragraph",
+                        FieldName = "ResetExplanation",
+                        Args = {
+                            Text = "Does Hades have you beat? Is the underworld security system TOO strong? Or would you simply like to take your"
+                             .. " \"field research\" to the next level? \\n\\n Mnemosyne will offer you assistance in wiping the memories of"
+                             .. " the Underworld to return to where this all begin, but your experiences, memories, and strengths will remain."
+                             .. " She will provide you with ample Nectar and Ambrosia infused with extract of the waters of Lethe, and you must simply give"
+                             .. " these to the members of the House of Hades, and all will fall into place. Don't worry about Hades' minions in the underworld"
+                             .. "... Mnemosyne has you covered. winky emoji. \\n\\n "
+                             .. " If desired, select a new file difficulty, and proceed to the next page to see how your current progress transforms"
+                             .. " after your deal with Mnemosyne. Note that this cannot be undone, so if there are things you want to finish up before"
+                             .. " resetting, do that first."
+                        }
+                    },
+                    {
+                        Type = "Text",
+                        SubType = "Subtitle",
+                        FieldName = "ResetSubtitle",
+                        Args = {
+                            Text = "Mnemosyne offers a helping hand ...",
+                        }
+                    },
+                }
+            
+        }
+    })
 end
 
 -- Courtyard Interface
@@ -2116,51 +2170,6 @@ ModUtil.Path.Wrap("OpenShrineUpgradeMenu", function (base, args)
     })
 end, ZyruIncremental)
 
-local shrineExpFactorTable = {
-	EnemyDamageShrineUpgrade = 1.05,
-	HealingReductionShrineUpgrade = 1.05,
-	ShopPricesShrineUpgrade = 1.1,
-	EnemyCountShrineUpgrade = 1.02,
-	BossDifficultyShrineUpgrade = 1.1,
-
-	EnemyHealthShrineUpgrade = 1.05,
-	EnemyEliteShrineUpgrade = 1.15,
-	MinibossCountShrineUpgrade = 1.1,
-	ForceSellShrineUpgrade = 1.2,
-	EnemySpeedShrineUpgrade = 1.1,
-
-	TrapDamageShrineUpgrade = 1.05,
-	MetaUpgradeStrikeThroughShrineUpgrade = 1.2,
-	EnemyShieldShrineUpgrade = 1.02,
-	ReducedLootChoicesShrineUpgrade = 1.25,
-	BiomeSpeedShrineUpgrade = 1.05,
-	NoInvulnerabilityShrineUpgrade = 1,
-}
-function ZyruIncremental.ComputeShrinePactExperienceMultiplier(args)
-    if args.Cached and ZyruIncremental.ShrinePactExperienceMultiplierCache ~= nil then
-        -- DebugPrint { Text = "returning cached shrine mult: " .. tostring(ZyruIncremental.ShrinePactExperienceMultiplierCache)}
-        return ZyruIncremental.ShrinePactExperienceMultiplierCache
-    end
-    local value = 1 -- multValue
-    local additiveValue = 1
-    local mixedValue = 1
-    for i, pactConditionName in ipairs(ShrineUpgradeOrder) do
-		local upgradeData = MetaUpgradeData[pactConditionName]
-        local expFactor = shrineExpFactorTable[pactConditionName]
-        local pactConditionCount = GetNumMetaUpgrades( pactConditionName ) or 0
-        if pactConditionCount > 0 then
-        
-            value = value * math.pow(expFactor, pactConditionCount)
-            additiveValue = additiveValue + (expFactor - 1) * pactConditionCount
-            mixedValue = mixedValue * ((expFactor - 1) * pactConditionCount + 1)
-        end
-
-        
-    end
-    -- DebugPrint { Text = "Mult: " .. tostring(value) ..  ", Mixed: " .. tostring(mixedValue) .. ", Additive: " .. tostring(additiveValue)}
-    ZyruIncremental.ShrinePactExperienceMultiplierCache = value
-    return value
-end
 function ZyruIncremental.UpdateShrineExperienceMultiplier(screen, button)
 
     ZyruIncremental.CreateOrUpdateComponent(screen, {

--- a/Mods/ZyruviasIncremental/Upgrades/ZyruIncrementalUpgradeData.lua
+++ b/Mods/ZyruviasIncremental/Upgrades/ZyruIncrementalUpgradeData.lua
@@ -519,6 +519,7 @@ ZyruIncremental.TraitData = {
         OnApplyFunctionArgs
         Source?
         Sources?
+        Persistence
     }
     ]]--
 ZyruIncremental.UpgradeData = {
@@ -546,6 +547,7 @@ ZyruIncremental.UpgradeData = {
                 },
             },
         },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     PoseidonHermesSynergyTrait = {
@@ -568,6 +570,7 @@ ZyruIncremental.UpgradeData = {
             },
         },
         Sources = { ZyruIncremental.Constants.Gods.POSEIDON, ZyruIncremental.Constants.Gods.HERMES },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     ArtemisHermesSynergyTrait = {
@@ -590,6 +593,7 @@ ZyruIncremental.UpgradeData = {
             },
         },
         Sources = { ZyruIncremental.Constants.Gods.ARTEMIS, ZyruIncremental.Constants.Gods.HERMES },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
     DionysusHermesSynergyTrait = {
         Name = "DionysusHermesSynergyTrait",
@@ -610,7 +614,8 @@ ZyruIncremental.UpgradeData = {
                 },
             },
         },
-        Source = "NULL" -- todo: fix, add, release, etc.
+        Source = "NULL", -- todo: fix, add, release, etc.
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
         -- Sources = { ZyruIncremental.Constants.Gods.DIONYSUS, ZyruIncremental.Constants.Gods.HERMES },
     },
 
@@ -634,6 +639,7 @@ ZyruIncremental.UpgradeData = {
             },
         },
         Sources = { ZyruIncremental.Constants.Gods.ARES, ZyruIncremental.Constants.Gods.HERMES },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     AphroditeHermesSynergyTrait = {
@@ -656,6 +662,7 @@ ZyruIncremental.UpgradeData = {
             },
         },
         Sources = { ZyruIncremental.Constants.Gods.APHRODITE, ZyruIncremental.Constants.Gods.HERMES },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     DemeterHermesSynergyTrait = {
@@ -678,6 +685,7 @@ ZyruIncremental.UpgradeData = {
             },
         },
         Sources = { ZyruIncremental.Constants.Gods.DEMETER, ZyruIncremental.Constants.Gods.HERMES },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     -- TODO: make this
@@ -701,6 +709,7 @@ ZyruIncremental.UpgradeData = {
             },
         },
         Sources = { ZyruIncremental.Constants.Gods.ATHENA, ZyruIncremental.Constants.Gods.HERMES },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     -----------------
@@ -752,6 +761,7 @@ ZyruIncremental.UpgradeData = {
             },
         },
         Source = ZyruIncremental.Constants.Gods.POSEIDON,
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     -- APHRODITE
@@ -774,6 +784,7 @@ ZyruIncremental.UpgradeData = {
                 },
             },
         },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     -- ARTEMIS LEGENDARY
@@ -793,6 +804,7 @@ ZyruIncremental.UpgradeData = {
                 OneOf = { "CritVulnerabilityTrait" },
             },
         },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     -- DIONYSUS LEFENGDARY
@@ -815,6 +827,7 @@ ZyruIncremental.UpgradeData = {
                 },
             },
         },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     -- ATHENA LEFENGDARY
@@ -856,6 +869,7 @@ ZyruIncremental.UpgradeData = {
                 },
             },
         },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     -- CHAOS LEGENDARY
@@ -876,6 +890,7 @@ ZyruIncremental.UpgradeData = {
                 },
             },
         },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
 
     },
 
@@ -899,6 +914,7 @@ ZyruIncremental.UpgradeData = {
                 },
             },
         },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     -- HermesAfterImageLegendaryUpgrade = {
@@ -985,6 +1001,7 @@ ZyruIncremental.UpgradeData = {
                 },
             },
         },
+        Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     },
 
     -- ZEUS LEGENDARY
@@ -1006,6 +1023,7 @@ ZyruIncremental.UpgradeData = {
     --             },
     --         },
     --     },
+    --  Persistence = ZyruIncremental.Constants.Persistence.PRESTIGE,
     -- },
 
 
@@ -1022,6 +1040,7 @@ ZyruIncremental.UpgradeData = {
         OnApplyFunctionArgs = {
             ZeusRarityBonus = 10,
         },
+        Persistence = ZyruIncremental.Constants.Persistence.NONE,
     },
 
     
@@ -1035,6 +1054,7 @@ ZyruIncremental.UpgradeData = {
         OnApplyFunctionArgs = {
             PoseidonRarityBonus = 10,
         },
+        Persistence = ZyruIncremental.Constants.Persistence.NONE,
     },
 
     
@@ -1048,6 +1068,7 @@ ZyruIncremental.UpgradeData = {
         OnApplyFunctionArgs = {
             AthenaRarityBonus = 10,
         },
+        Persistence = ZyruIncremental.Constants.Persistence.NONE,
     },
 
     
@@ -1061,6 +1082,7 @@ ZyruIncremental.UpgradeData = {
         OnApplyFunctionArgs = {
             AresRarityBonus = 10,
         },
+        Persistence = ZyruIncremental.Constants.Persistence.NONE,
     },
 
     AphroditeRarityUpgrade = {
@@ -1073,6 +1095,7 @@ ZyruIncremental.UpgradeData = {
         OnApplyFunctionArgs = {
             AphroditeRarityBonus = 10,
         },
+        Persistence = ZyruIncremental.Constants.Persistence.NONE,
     },
 
     ArtemisRarityUpgrade = {
@@ -1085,6 +1108,7 @@ ZyruIncremental.UpgradeData = {
         OnApplyFunctionArgs = {
             ArtemisRarityBonus = 10,
         },
+        Persistence = ZyruIncremental.Constants.Persistence.NONE,
     },
 
     DionysusRarityUpgrade = {
@@ -1097,6 +1121,7 @@ ZyruIncremental.UpgradeData = {
         OnApplyFunctionArgs = {
             DionysusRarityBonus = 10,
         },
+        Persistence = ZyruIncremental.Constants.Persistence.NONE,
     },
 
     HermesRarityUpgrade = {
@@ -1109,6 +1134,7 @@ ZyruIncremental.UpgradeData = {
         OnApplyFunctionArgs = {
             HermesRarityBonus = 10,
         },
+        Persistence = ZyruIncremental.Constants.Persistence.NONE,
     },
 
     DemeterRarityUpgrade = {
@@ -1121,6 +1147,7 @@ ZyruIncremental.UpgradeData = {
         OnApplyFunctionArgs = {
             DemeterRarityBonus = 10,
         },
+        Persistence = ZyruIncremental.Constants.Persistence.NONE,
     },
 
     -------------------

--- a/Mods/ZyruviasIncremental/Upgrades/ZyruIncrementalUpgrades.lua
+++ b/Mods/ZyruviasIncremental/Upgrades/ZyruIncrementalUpgrades.lua
@@ -4,7 +4,7 @@ function ZyruIncremental.AddUpgrade(upgrade, args)
         return false
     end
     if upgrade == nil then
-        DebugPrint { Text = "Passed nil upgrade"}
+        DebugPrint {Text = "Passed nil upgrade"}
         return false
     end
     local upgradeName = upgrade.Name
@@ -17,7 +17,7 @@ function ZyruIncremental.AddUpgrade(upgrade, args)
     if upgrade.OnApplyFunction ~= nil then
         _G[upgrade.OnApplyFunction](upgrade.OnApplyFunctionArgs)
     end
-    
+
     if upgrade.OnApplyFunctions ~= nil then
         for k, functionName in ipairs(upgrade.OnApplyFunctions) do
             local functionArgs = upgrade.OnApplyFunctionArgs[k]
@@ -35,7 +35,7 @@ function ZyruIncremental.RemoveUpgrade(upgradeName, args)
         return false
     end
 
-    for i,v in ipairs(ZyruIncremental.Data.UpgradeData) do
+    for i, v in ipairs(ZyruIncremental.Data.UpgradeData) do
         if v == upgradeName then
             table.remove(ZyruIncremental.Data.UpgradeData, i)
             -- DebugPrint { Text = "Removing " .. upgradeName .. " from GameState. Current upgrade values:"}
@@ -43,7 +43,6 @@ function ZyruIncremental.RemoveUpgrade(upgradeName, args)
             return
         end
     end
-
 end
 
 function ZyruIncremental.AddTraitToTraitData(args)
@@ -73,13 +72,7 @@ end
 
 function ZyruIncremental.MergeDataArrays(args)
     for i, mergeArgs in ipairs(args) do
-        ModUtil.Path.Set(
-            mergeArgs.Array,
-            ModUtil.Array.Join(
-                ModUtil.Path.Get(mergeArgs.Array),
-                mergeArgs.Value
-            )
-        )
+        ModUtil.Path.Set(mergeArgs.Array, ModUtil.Array.Join(ModUtil.Path.Get(mergeArgs.Array), mergeArgs.Value))
     end
 end
 
@@ -145,11 +138,11 @@ end
 
 function ZyruIncremental.AttemptPurchaseUpgrade(screen, button)
     local upgrade = button.Upgrade
-    DebugPrint { Text = ModUtil.ToString.Shallow(upgrade) }
+    DebugPrint {Text = ModUtil.ToString.Shallow(upgrade)}
     if ZyruIncremental.HasUpgrade(upgrade) and not ZyruIncremental.IsUpgradeRepeatable(upgrade) then
         -- TODO: CannotPurchaseVoiceLines all but last?
-        DebugPrint { Text = "Already have upgrade: " .. upgrade.Name }
-		thread( PlayVoiceLines, HeroVoiceLines.CannotPurchaseVoiceLines, true )
+        DebugPrint {Text = "Already have upgrade: " .. upgrade.Name}
+        thread(PlayVoiceLines, HeroVoiceLines.CannotPurchaseVoiceLines, true)
         return
     end
     if IsUpgradeAffordable(upgrade) then
@@ -158,11 +151,11 @@ function ZyruIncremental.AttemptPurchaseUpgrade(screen, button)
         -- add upgrade to save
         ZyruIncremental.AddUpgrade(upgrade)
         -- exhibit signs of self awareness
-		thread( PlayVoiceLines, HeroVoiceLines.GenericUpgradePickedVoiceLines, true )
-        DebugPrint { Text = "Purchased upgrade: " .. upgrade.Name }
+        thread(PlayVoiceLines, HeroVoiceLines.GenericUpgradePickedVoiceLines, true)
+        DebugPrint {Text = "Purchased upgrade: " .. upgrade.Name}
     else
-		thread( PlayVoiceLines, HeroVoiceLines.NotEnoughCurrencyVoiceLines, true )
-        DebugPrint { Text = "Cannot purchase upgrade: " .. upgrade.Name }
+        thread(PlayVoiceLines, HeroVoiceLines.NotEnoughCurrencyVoiceLines, true)
+        DebugPrint {Text = "Cannot purchase upgrade: " .. upgrade.Name}
     end
     -- reupdate the info screen in case of changing costs or whatever
     UpdateUpgradeInfoScreen(screen, upgrade, button)
@@ -176,7 +169,6 @@ function AugmentTransientState(args)
         elseif type(val) == "string" then
             ZyruIncremental.TransientState[name] = val
         end
-
     end
 end
 
@@ -209,4 +201,15 @@ function ApplyTransientPatches(args)
             end
         end
     end
+end
+
+function ZyruIncremental.UpgradePresistsThroughPrestige(upgradeName, prestigeTierValue)
+    prestigeTierValue = prestigeTierValue or 1
+    local upgrade = ZyruIncremental.GetUpgradeByName(upgradeName)
+    if upgrade and upgrade.Persistence == ZyruIncremental.Constants.Prestige.NONE then
+        return false
+    elseif upgrade and upgrade.Persistence == ZyruIncremental.Constants.Prestige.PRESTIGE and prestigeTierValue <= 1 then
+        return true
+    end
+    return false
 end

--- a/Mods/ZyruviasIncremental/Upgrades/ZyruIncrementalUpgrades.lua
+++ b/Mods/ZyruviasIncremental/Upgrades/ZyruIncrementalUpgrades.lua
@@ -206,9 +206,9 @@ end
 function ZyruIncremental.UpgradePresistsThroughPrestige(upgradeName, prestigeTierValue)
     prestigeTierValue = prestigeTierValue or 1
     local upgrade = ZyruIncremental.GetUpgradeByName(upgradeName)
-    if upgrade and upgrade.Persistence == ZyruIncremental.Constants.Prestige.NONE then
+    if upgrade and upgrade.Persistence == ZyruIncremental.Constants.Persistence.NONE then
         return false
-    elseif upgrade and upgrade.Persistence == ZyruIncremental.Constants.Prestige.PRESTIGE and prestigeTierValue <= 1 then
+    elseif upgrade and upgrade.Persistence == ZyruIncremental.Constants.Persistence.PRESTIGE and prestigeTierValue <= 1 then
         return true
     end
     return false

--- a/Mods/ZyruviasIncremental/ZyruIncremental.lua
+++ b/Mods/ZyruviasIncremental/ZyruIncremental.lua
@@ -2,8 +2,8 @@ ModUtil.Mod.Register("ZyruIncremental")
 
 local config = {}
 ZyruIncremental.Config = config
-ZyruIncremental.CurrentVersion = 3
-ZyruIncremental.CurrentVersionString = "1.0.2"
+ZyruIncremental.CurrentVersion = 6
+ZyruIncremental.CurrentVersionString = "1.1.0"
 ZyruIncremental.TransientState = {}
 
 ZyruIncremental.Constants = {

--- a/Mods/ZyruviasIncremental/ZyruIncremental.lua
+++ b/Mods/ZyruviasIncremental/ZyruIncremental.lua
@@ -7,83 +7,93 @@ ZyruIncremental.CurrentVersionString = "1.0.2"
 ZyruIncremental.TransientState = {}
 
 ZyruIncremental.Constants = {
-    SaveFile = {
-      -- starting point
-      EPILOGUE = "Epilogue",
-      FRESH_FILE = "Fresh File",
-      -- difficulty
-      EASY = "Easy",
-      STANDARD = "Standard",
-      HARD = "Hard",
-      HELL = "Hell",
-      FREEPLAY = "Freeplay",
+  SaveFile = {
+    -- starting point
+    EPILOGUE = "Epilogue",
+    FRESH_FILE = "Fresh File",
+    -- difficulty
+    EASY = "Easy",
+    STANDARD = "Standard",
+    HARD = "Hard",
+    HELL = "Hell",
+    FREEPLAY = "Freeplay"
+  },
+  Difficulty = {
+    Keys = {
+      HEALTH_SCALIING = "HealthScaling",
+      COST_SCALING = "CostScaling",
+      INCOMING_DAMAGE_SCALING = "IncomingDamageScaling"
     },
-    Difficulty = {
-      Keys = {
-        HEALTH_SCALIING = "HealthScaling",
-        COST_SCALING = "CostScaling",
-        INCOMING_DAMAGE_SCALING = "IncomingDamageScaling",
-      },
-      HealthScaling = {
-        Easy = 1.02,
-        Standard = 1.04,
-        Hard = 1.06,
-        Hell = 1.10
-      },
-      CostScaling = {
-        Easy = 1.00,
-        Standard = 1.01,
-        Hard = 1.02,
-        Hell = 1.05
-      },
-      IncomingDamageScaling = {
-        Easy = 1.02,
-        Standard = 1.04,
-        Hard = 1.06,
-        Hell = 1.10
-      }
+    HealthScaling = {
+      Easy = 1.02,
+      Standard = 1.04,
+      Hard = 1.06,
+      Hell = 1.10
     },
-    Components = {
-      RECTANGLE_01_HEIGHT = 270,
-      RECTANGLE_01_WIDTH = 480,
-      PROGRESS_BAR_SCALE_PROPORTION_X = 1,
-      PROGRESS_BAR_SCALE_PROPORTION_Y = 0.05
+    CostScaling = {
+      Easy = 1.00,
+      Standard = 1.01,
+      Hard = 1.02,
+      Hell = 1.05
     },
-    Gods = {
-      ZEUS = "Zeus",
-      POSEIDON = "Poseidon",
-      ATHENA = "Athena",
-      ARES = "Ares",
-      APHRODITE = "Aphrodite",
-      ARTEMIS = "Artemis",
-      DIONYSUS = "Dionysus",
-      DEMETER = "Demeter",
-      HERMES = "Hermes",
-      CHAOS = "Chaos",
-    },
-    Upgrades = {
-      Types = {
-        PURCHASE_BOON = "Purchase Boon",
-        AUGMENT_RARITY = "Augment Rarity Bonus"
-      },
-    },
-    Settings = {
-      EXP_ON_HIT = "On hit",
-      EXP_ON_DEATH_BY_BOON = "On kill, aggregated by Boon",
-      EXP_ON_DEATH_BY_GOD = "On kill, aggregated by God",
-      LEVEL_POPUP = "Overhead notification only",
-      LEVEL_VOICELINE = "Voiceline only",
-      LEVEL_POPUP_VOICELINE = "Overhead and Voiceline",
-      LEVEL_PORTRAIT = "Portrait and Voiceline",
-      LEVEL_ALL = "All settings simultaneously"
+    IncomingDamageScaling = {
+      Easy = 1.02,
+      Standard = 1.04,
+      Hard = 1.06,
+      Hell = 1.10
     }
+  },
+  Components = {
+    RECTANGLE_01_HEIGHT = 270,
+    RECTANGLE_01_WIDTH = 480,
+    PROGRESS_BAR_SCALE_PROPORTION_X = 1,
+    PROGRESS_BAR_SCALE_PROPORTION_Y = 0.05
+  },
+  Gods = {
+    ZEUS = "Zeus",
+    POSEIDON = "Poseidon",
+    ATHENA = "Athena",
+    ARES = "Ares",
+    APHRODITE = "Aphrodite",
+    ARTEMIS = "Artemis",
+    DIONYSUS = "Dionysus",
+    DEMETER = "Demeter",
+    HERMES = "Hermes",
+    CHAOS = "Chaos"
+  },
+  Upgrades = {
+    Types = {
+      PURCHASE_BOON = "Purchase Boon",
+      AUGMENT_RARITY = "Augment Rarity Bonus"
+    }
+  },
+  Settings = {
+    EXP_ON_HIT = "On hit",
+    EXP_ON_DEATH_BY_BOON = "On kill, aggregated by Boon",
+    EXP_ON_DEATH_BY_GOD = "On kill, aggregated by God",
+    LEVEL_POPUP = "Overhead notification only",
+    LEVEL_VOICELINE = "Voiceline only",
+    LEVEL_POPUP_VOICELINE = "Overhead and Voiceline",
+    LEVEL_PORTRAIT = "Portrait and Voiceline",
+    LEVEL_ALL = "All settings simultaneously"
+  },
+  Persistence = {
+    NONE = "NONE",
+    PRESTIGE = "PRESTIGE"
   }
+}
 
-ModUtil.Path.Wrap("SetRichPresence", function (base, args)
-    base { Key = "steam_display", Value = "#Playing Zyruvias's Incremental Mod" }
-    base { Key = "status", Value = "#Playing Zyruvias's Incremental Mod" }
-end, ZyruIncremental)
-  
-ModUtil.LoadOnce(function ()
-  ApplyTransientPatches({})
-end)
+ModUtil.Path.Wrap(
+  "SetRichPresence",
+  function(base, args)
+    base {Key = "steam_display", Value = "#Playing Zyruvias's Incremental Mod"}
+    base {Key = "status", Value = "#Playing Zyruvias's Incremental Mod"}
+  end,
+  ZyruIncremental
+)
+
+ModUtil.LoadOnce(
+  function()
+    ApplyTransientPatches({})
+  end
+)

--- a/Mods/ZyruviasIncremental/ZyruIncrementalUtils.lua
+++ b/Mods/ZyruviasIncremental/ZyruIncrementalUtils.lua
@@ -107,7 +107,7 @@ function ZyruIncremental.ComputeRarityDistribution( rarityBonus )
   end
 
   chances[lastRarity] = chances[lastRarity] + 1 - previousValue
-
+  DebugPrint { Text = rarityBonus .. " " .. ModUtil.ToString.Deep(chances)}
   ZyruIncremental.RarityArrayMap[tostring(rarityBonus)] = chances
   return chances
 

--- a/Mods/ZyruviasIncremental/ZyruIncrementalUtils.lua
+++ b/Mods/ZyruviasIncremental/ZyruIncrementalUtils.lua
@@ -208,6 +208,19 @@ end, ZyruIncremental)
 -- TODO: wrapping setupRunData versus just redoing it manually
 SetupRunData()
 
+function ZyruIncremental.GetUpgradeByName(upgradeName)
+  local upgrade = ZyruIncremental.UpgradeData[upgradeName]
+  if upgrade == nil then
+    -- check upgrades themselves for a name match, reworked names recently
+    for u, uData in pairs(ZyruIncremental.UpgradeData) do
+      if uData.Name == upgradeName then
+        upgrade = uData
+        break
+      end
+    end
+  end
+  return upgrade
+end
 
 -- Dev scripts
 ModUtil.LoadOnce( function ( )


### PR DESCRIPTION
# Major Content Update: Heat and Prestige
* Pact of Punishment settings now grant an additional EXP modifier to incentivize players to take additional heat settings.
* Players can now "reset" their savefile to earn additional EXP multipliers, earn additional rewards, and more! This is a standard "ascension/prestige/transcension layer" mechanic core to many incremental games, not a hard reset.

# Balancing
* Survival EXP is buffed from 100% - 2% per kill, to 20% + 2% per kill to reward more effective play rather than punishing it.

# Bug Fixes
* Fixed UI inconsistency bugs.
* Fixed Codex crashing for certain entries.
* Fixed bug where people who started with Fresh File beginning on file creation are not unnecessarily punished on the 11th clear run and onward.
* Fixed massive armor scaling issue for late game players.
